### PR TITLE
絶妙な遅さにする

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -104,7 +104,7 @@ module Isuconp
         digest "#{password}:#{calculate_salt(account_name)}"
       end
 
-      def make_posts(max_created_at)
+      def get_posts(max_created_at)
         if max_created_at.nil?
           results = db.query('SELECT id,user_id,body,created_at FROM posts ORDER BY created_at DESC')
         else
@@ -212,14 +212,14 @@ module Isuconp
         user = { id: 0 }
       end
 
-      posts = make_posts(nil)
+      posts = get_posts(nil)
 
       erb :index, layout: :layout, locals: { posts: posts, user: user }
     end
 
     get '/posts' do
       max_created_at = params['max_created_at']
-      posts = make_posts(max_created_at.nil? ? nil : Time.parse(max_created_at))
+      posts = get_posts(max_created_at.nil? ? nil : Time.parse(max_created_at))
 
       erb :posts, layout: :layout, locals: { posts: posts }
     end

--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -114,20 +114,20 @@ module Isuconp
         end
 
         posts = []
-        results.each do |post|
+        results.to_a.each do |post|
           post[:comment_count] = db.prepare('SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = ?').execute(
             post[:id]
           ).first[:count]
 
           comments = db.prepare('SELECT * FROM `comments` WHERE `post_id` = ? ORDER BY `created_at` DESC LIMIT 3').execute(
             post[:id]
-          )
+          ).to_a
           comments.each do |comment|
             comment[:user] = db.prepare('SELECT * FROM `users` WHERE `id` = ?').execute(
               comment[:user_id]
             ).first
           end
-          post[:comments] = comments
+          post[:comments] = comments.reverse
 
           post[:user] = db.prepare('SELECT * FROM `users` WHERE `id` = ?').execute(
             post[:user_id]

--- a/webapp/ruby/views/index.erb
+++ b/webapp/ruby/views/index.erb
@@ -32,7 +32,7 @@
   </form>
 </div>
 
-<%= erb :posts, layout: :layout, locals: { posts: posts, count: count, comments: comments, users: users, user: user } %>
+<%= erb :posts, layout: :layout, locals: { posts: posts, user: user } %>
 
 <div id="isu-post-more">
   <button id="isu-post-more-btn">More</button>

--- a/webapp/ruby/views/index.erb
+++ b/webapp/ruby/views/index.erb
@@ -32,7 +32,7 @@
   </form>
 </div>
 
-<%= erb :posts, layout: :layout, locals: { posts: posts, user: user } %>
+<%= erb :posts, layout: :layout, locals: { posts: posts } %>
 
 <div id="isu-post-more">
   <button id="isu-post-more-btn">More</button>

--- a/webapp/ruby/views/posts.erb
+++ b/webapp/ruby/views/posts.erb
@@ -1,37 +1,30 @@
 <div>
-  <% display = 0 %>
-  <% posts.each do |p| %>
-  <%   break if display > 30 %>
-  <%   display = display + 1 %>
-  <div class="isu-post" data-max="<%= p[:created_at] %>">
+  <% posts.each do |post| %>
+  <div class="isu-post" data-max="<%= post[:created_at] %>">
     <div class="isu-post-image">
-      <img src="/image/<%= p[:id] %>" class="isu-image">
+      <img src="/image/<%= post[:id] %>" class="isu-image">
     </div>
     <div class="isu-post-text">
       <span class="isu-post-account-name">
-        <%= escape_html(users[p[:user_id]][:account_name]) %>
+        <%= escape_html(post[:user][:account_name]) %>
       </span>
-      <%= escape_html(p[:body]).gsub(/\r?\n/, '<br>') %>
+      <%= escape_html(post[:body]).gsub(/\r?\n/, '<br>') %>
     </div>
     <div class="isu-post-comment">
-      <% if count[p[:id]] %>
-        <div class="isu-post-comment-count">
-          comments: <b><%= escape_html(count[p[:id]]) %></b>
-        </div>
-      <% end %>
-
-      <% if comments[p[:id]] %>
-      <%   comments[p[:id]].each do |c| %>
-      <div class="isu-comment-text">
-        <span class="isu-comment-account-name"><%= escape_html(users[c[:user_id]][:account_name]) %></span>
-        <%= escape_html(c[:comment]) %>
+      <div class="isu-post-comment-count">
+        comments: <b><%= escape_html(post[:comment_count]) %></b>
       </div>
-      <%   end %>
+
+      <% post[:comments].each do |comment| %>
+      <div class="isu-comment-text">
+        <span class="isu-comment-account-name"><%= escape_html(comment[:user][:account_name]) %></span>
+        <%= escape_html(comment[:comment]) %>
+      </div>
       <% end %>
       <div class="isu-comment-form">
         <form method="post" action="/comment">
           <input type="text" name="comment">
-          <input type="hidden" name="post_id" value="<%= p[:id] %>">
+          <input type="hidden" name="post_id" value="<%= post[:id] %>">
           <input type="hidden" name="csrf_token" value="<%= escape_html session.id %>">
           <input type="submit" name="submit" value="submit">
         </form>


### PR DESCRIPTION
やったこと

* タイムラインを作るときは画像データを取得しないようにして巨大な転送が起こらないようにする
* commentsを全件取得して連想配列に詰めなおしてたのが遅すぎたので、ふつうのN+1クエリに変更
* タイムラインではコメントを3件までしか表示しないようにする（そうじゃないとカウントを出してる意味が無い）
* usersも全件取得して連想配列アクセスするのではなくN+1クエリにする
* / と /posts で同じ実装なのでメソッドに切り出す
* 1文字の変数を減らす

