### PR TITLE
docker-compose 対応

### DIFF
--- a/benchmarker/checker/session.go
+++ b/benchmarker/checker/session.go
@@ -44,14 +44,6 @@ func NewSession() *Session {
 		Transport: w.Transport,
 		Jar:       jar,
 		Timeout:   time.Duration(10) * time.Second,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if req.Method == http.MethodGet {
-				// POST からのリダイレクト GET で content-type: mutilpart/form-data を付けると
-				// Rack が EOFError で死ぬのでヘッダを消しておく
-				req.Header.Del("Content-Type")
-			}
-			return nil
-		},
 	}
 
 	return w

--- a/benchmarker/checker/session.go
+++ b/benchmarker/checker/session.go
@@ -44,6 +44,14 @@ func NewSession() *Session {
 		Transport: w.Transport,
 		Jar:       jar,
 		Timeout:   time.Duration(10) * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if req.Method == http.MethodGet {
+				// POST からのリダイレクト GET で content-type: mutilpart/form-data を付けると
+				// Rack が EOFError で死ぬのでヘッダを消しておく
+				req.Header.Del("Content-Type")
+			}
+			return nil
+		},
 	}
 
 	return w

--- a/benchmarker/cli.go
+++ b/benchmarker/cli.go
@@ -22,7 +22,7 @@ const (
 	FailThreshold     = 5
 	InitializeTimeout = time.Duration(10) * time.Second
 	BenchmarkTimeout  = 60 * time.Second
-	WaitAfterTimeout  = 10
+	WaitAfterTimeout  = 10 * time.Second
 
 	PostsPerPage = 20
 )
@@ -54,6 +54,7 @@ func (cli *CLI) Run(args []string) int {
 		userdata string
 
 		benchmarkTimeout time.Duration
+		waitAfterTimeout time.Duration
 
 		version bool
 		debug   bool
@@ -70,6 +71,7 @@ func (cli *CLI) Run(args []string) int {
 	flags.StringVar(&userdata, "u", "", "userdata directory")
 
 	flags.DurationVar(&benchmarkTimeout, "benchmark-timeout", BenchmarkTimeout, "benchmark timeout")
+	flags.DurationVar(&waitAfterTimeout, "wait-after-timeout", WaitAfterTimeout, "wait after timeout")
 
 	flags.BoolVar(&version, "version", false, "Print version information and quit.")
 
@@ -183,7 +185,7 @@ L:
 		}
 	}
 
-	time.Sleep(WaitAfterTimeout)
+	time.Sleep(waitAfterTimeout)
 
 	var msgs []string
 	if !debug {

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - app
 
   app:
+    cpus: 1
     mem_limit: 1g
     build: ruby/ # Go実装の場合は golang/
     environment:
@@ -24,10 +25,11 @@ services:
       - mysql
       - memcached
     volumes:
-      - ./public:/public
+      - ./public:/home/public
     init: true
 
   mysql:
+    cpus: 1
     mem_limit: 1g
     image: mysql:8.0.25
     environment:

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '2.2'
+services:
+  nginx:
+    image: nginx:1.20.0
+    volumes:
+      - ./etc/nginx/conf.d:/etc/nginx/conf.d
+      - ./public:/public
+    ports:
+      - "80:80"
+    links:
+      - app
+
+  app:
+    mem_limit: 1g
+    build: ruby/ # Go実装の場合は golang/
+    environment:
+      ISUCONP_DB_HOST: mysql
+      ISUCONP_DB_PORT: 3306
+      ISUCONP_DB_USER: root
+      ISUCONP_DB_PASSWORD: root
+      ISUCONP_DB_NAME: isuconp
+      ISUCONP_MEMCACHED_ADDRESS: memcached:11211
+    links:
+      - mysql
+      - memcached
+    volumes:
+      - ./public:/public
+    init: true
+
+  mysql:
+    mem_limit: 1g
+    image: mysql:8.0.25
+    environment:
+      - "TZ=Asia/Tokyo"
+      - "MYSQL_ROOT_PASSWORD=root"
+    volumes:
+      - mysql:/var/lib/mysql
+      - ./etc/mysql/conf.d:/etc/mysql/conf.d
+    ports:
+      - "3306:3306"
+
+  memcached:
+    image: memcached:1.6.9
+
+volumes:
+  mysql:

--- a/webapp/etc/mysql/conf.d/my.cnf
+++ b/webapp/etc/mysql/conf.d/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+default_authentication_plugin=mysql_native_password

--- a/webapp/etc/nginx/conf.d/default.conf
+++ b/webapp/etc/nginx/conf.d/default.conf
@@ -1,0 +1,13 @@
+server {
+  listen 80;
+
+  client_max_body_size 10m;
+  root /public/;
+
+  location / {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass http://app:8080;
+  }
+}

--- a/webapp/golang/Dockerfile
+++ b/webapp/golang/Dockerfile
@@ -3,5 +3,5 @@ FROM golang:1.16.4
 RUN mkdir -p /home/webapp
 COPY . /home/webapp
 WORKDIR /home/webapp
-RUN make app
+RUN make
 CMD ./app

--- a/webapp/golang/Dockerfile
+++ b/webapp/golang/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.16.4
+
+RUN mkdir -p /home/webapp
+COPY . /home/webapp
+WORKDIR /home/webapp
+RUN make app
+CMD ./app

--- a/webapp/golang/Makefile
+++ b/webapp/golang/Makefile
@@ -1,4 +1,4 @@
 all: app
 
-app: *.go
+app: *.go go.*
 	go build -o app

--- a/webapp/golang/Makefile
+++ b/webapp/golang/Makefile
@@ -1,4 +1,4 @@
 all: app
 
-app: *.go go.*
+app: *.go go.mod go.sum
 	go build -o app

--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -70,7 +70,11 @@ type Comment struct {
 }
 
 func init() {
-	memcacheClient := memcache.New("localhost:11211")
+	memdAddr := os.Getenv("ISUCONP_MEMCACHED_ADDRESS")
+	if memdAddr == "" {
+		memdAddr = "localhost:11211"
+	}
+	memcacheClient := memcache.New(memdAddr)
 	store = gsm.NewMemcacheStore(memcacheClient, "iscogram_", []byte("sendagaya"))
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 }
@@ -870,7 +874,7 @@ func main() {
 	mux.HandleFunc(pat.Get("/admin/banned"), getAdminBanned)
 	mux.HandleFunc(pat.Post("/admin/banned"), postAdminBanned)
 	mux.HandleFunc(Regexp(regexp.MustCompile(`^/@(?P<accountName>[a-zA-Z]+)$`)), getAccountName)
-	mux.Handle(pat.Get("/*"), http.FileServer(http.Dir("../public")))
+	mux.Handle(pat.Get("/*"), http.FileServer(http.Dir("../../public")))
 
 	log.Fatal(http.ListenAndServe(":8080", mux))
 }

--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -872,5 +872,5 @@ func main() {
 	mux.HandleFunc(Regexp(regexp.MustCompile(`^/@(?P<accountName>[a-zA-Z]+)$`)), getAccountName)
 	mux.Handle(pat.Get("/*"), http.FileServer(http.Dir("../public")))
 
-	log.Fatal(http.ListenAndServe(":8000", mux))
+	log.Fatal(http.ListenAndServe(":8080", mux))
 }

--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -874,7 +874,7 @@ func main() {
 	mux.HandleFunc(pat.Get("/admin/banned"), getAdminBanned)
 	mux.HandleFunc(pat.Post("/admin/banned"), postAdminBanned)
 	mux.HandleFunc(Regexp(regexp.MustCompile(`^/@(?P<accountName>[a-zA-Z]+)$`)), getAccountName)
-	mux.Handle(pat.Get("/*"), http.FileServer(http.Dir("../../public")))
+	mux.Handle(pat.Get("/*"), http.FileServer(http.Dir("../public")))
 
 	log.Fatal(http.ListenAndServe(":8080", mux))
 }

--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:3.0.1-buster
+
+RUN mkdir -p /home/webapp
+COPY . /home/webapp
+WORKDIR /home/webapp
+RUN gem install bundler:2.2.16
+RUN bundle config set --local path 'vendor/bundle'
+RUN bundle install
+CMD bundle exec foreman start

--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -6,7 +6,7 @@ require 'rack/session/dalli'
 
 module Isuconp
   class App < Sinatra::Base
-    use Rack::Session::Dalli, autofix_keys: true, secret: ENV['ISUCONP_SESSION_SECRET'] || 'sendagaya'
+    use Rack::Session::Dalli, autofix_keys: true, secret: ENV['ISUCONP_SESSION_SECRET'] || 'sendagaya', memcache_server: ENV['ISUCONP_MEMCACHED_ADDRESS'] || 'localhost:11211'
     use Rack::Flash
     set :public_folder, File.expand_path('../../public', __FILE__)
 

--- a/webapp/ruby/unicorn_config.rb
+++ b/webapp/ruby/unicorn_config.rb
@@ -1,3 +1,3 @@
 worker_processes 1
 preload_app true
-listen "127.0.0.1:8080"
+listen "0.0.0.0:8080"


### PR DESCRIPTION
docker-compose で起動できるようにしました。
ひとまず Go と Ruby のみです。

各種イメージは現時点での最新と思われるものを使用しています。

- Go 1.16.4
- Ruby 3.0.1
- nginx 1.20.0
- memcached 1.6.9
- MySQL 8.0.25

memcachedの接続先が localhost とは限らなくなるため、接続先を指定する ISUCONP_MEMCACHED_ADDRESS という環境変数を追加しました。