### PR TITLE
リダイレクトする場合はContent-Typeヘッダを消す

### DIFF
--- a/benchmarker/checker/session.go
+++ b/benchmarker/checker/session.go
@@ -44,6 +44,14 @@ func NewSession() *Session {
 		Transport: w.Transport,
 		Jar:       jar,
 		Timeout:   time.Duration(10) * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if req.Method == http.MethodGet {
+				// POST からのリダイレクト GET で content-type: mutilpart/form-data を付けると
+				// Rack が EOFError で死ぬのでヘッダを消しておく
+				req.Header.Del("Content-Type")
+			}
+			return nil
+		},
 	}
 
 	return w


### PR DESCRIPTION
POST からのリダイレクト GET で `content-type: mutilpart/form-data` を付けると
Rack が EOFError で死ぬので削除しました。
仕様的にはGETにContent-Typeが付いていても問題ない気がするので、Rackの問題かもしれませんが死なないようにしておきます。