### PR TITLE
Fixed error when already time_zone is JST.

### DIFF
--- a/provisioning/image/ansible/01_user.yml
+++ b/provisioning/image/ansible/01_user.yml
@@ -5,7 +5,7 @@
   become: yes
   tasks:
     - name: change timezone to JST
-      shell: cp -p /usr/share/zoneinfo/Japan /etc/localtime
+      shell: cp -p /usr/share/zoneinfo/Japan /etc/localtime || true
     - group: name=wheel
     - user: name=isucon groups=wheel shell=/bin/bash
     - copy: src=../files/etc/profile.d/bashrc dest=/home/isucon/.profile owner=isucon mode=755


### PR DESCRIPTION
To fix error when already time_zone is JST, add `|| true` after cp.

```TASK [change timezone to JST] *********************************************************************************************************************************************************
fatal: [shanai-isucon-app-01]: FAILED! => {"changed": true, "cmd": "cp -p /usr/share/zoneinfo/Japan /etc/localtime", "delta": "0:00:00.004917", "end": "2021-05-31 13:40:00.740000", "msg": "non-zero return code", "rc": 1, "start": "2021-05-31 13:40:00.735083", "stderr": "cp: '/usr/share/zoneinfo/Japan' and '/etc/localtime' are the same file", "stderr_lines": ["cp: '/usr/share/zoneinfo/Japan' and '/etc/localtime' are the same file"], "stdout": "", "stdout_lines": []}```