### PR TITLE
my.cnfを直接マウントするように変更

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - "MYSQL_ROOT_PASSWORD=root"
     volumes:
       - mysql:/var/lib/mysql
-      - ./etc/mysql/conf.d:/etc/mysql/conf.d
+      - ./etc/mysql/conf.d/my.cnf:/etc/my.cnf
       - ./sql:/docker-entrypoint-initdb.d
     ports:
       - "3306:3306"


### PR DESCRIPTION
mysql/mysql-serverではmy.cnfを/etc/my.cnfを置き換える形でマウントする必要がありました
(以前のmysqlのほうのイメージとは変わっているのでこうしないと変更が効きません)
https://dev.mysql.com/doc/refman/8.0/en/docker-mysql-more-topics.html