### PR TITLE
GETの場合にContent-Length: 0を設定する

### DIFF
--- a/webapp/etc/nginx/conf.d/default.conf
+++ b/webapp/etc/nginx/conf.d/default.conf
@@ -1,3 +1,16 @@
+log_format json escape=json '{"time":"$time_iso8601",'
+                                '"host":"$remote_addr",'
+                                '"port":$remote_port,'
+                                '"method":"$request_method",'
+                                '"uri":"$request_uri",'
+                                '"status":"$status",'
+                                '"body_bytes":$body_bytes_sent,'
+                                '"referer":"$http_referer",'
+                                '"ua":"$http_user_agent",'
+                                '"request_time":"$request_time",'
+                                '"response_time":"$upstream_response_time"}';
+access_log /var/log/nginx/access.log json;
+
 server {
   listen 80;
 
@@ -8,6 +21,15 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    # GETかつContent-Type: multipart/form-data の場合、Content-LengthがないとRackが500になる対処
+    # Goのhttp.Clientはリダイレクト時にContent-Typeヘッダを維持するのでPOST->GETで
+    # その状態になる
+    set $length $http_content_length;
+    if ($request_method = "GET") {
+      set $length 0;
+    }
+    proxy_set_header Content-Length $length;
     proxy_pass http://app:8080;
   }
 }

--- a/webapp/etc/nginx/conf.d/default.conf
+++ b/webapp/etc/nginx/conf.d/default.conf
@@ -1,16 +1,3 @@
-log_format json escape=json '{"time":"$time_iso8601",'
-                                '"host":"$remote_addr",'
-                                '"port":$remote_port,'
-                                '"method":"$request_method",'
-                                '"uri":"$request_uri",'
-                                '"status":"$status",'
-                                '"body_bytes":$body_bytes_sent,'
-                                '"referer":"$http_referer",'
-                                '"ua":"$http_user_agent",'
-                                '"request_time":"$request_time",'
-                                '"response_time":"$upstream_response_time"}';
-access_log /var/log/nginx/access.log json;
-
 server {
   listen 80;
 


### PR DESCRIPTION
RackがGETかつcontent-type: mutilpart/form-dataの場合に500になる問題です

以前 #204 でベンチマーカー側で対処を入れましたが、k6のhttp clientも
Goで実装されているため同様の現象が起きていました。
nginx側で、GETの場合は常にContent-Lengthを設定することで回避できたので
設定を追加しました