### PR TITLE
change compose version from v2.2 to Compose specification

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
   nginx:
     image: nginx:1.22
@@ -11,8 +10,6 @@ services:
       - app
 
   app:
-    cpus: 1
-    mem_limit: 1g
     # Go実装の場合は golang/ PHP実装の場合は php/
     build: ruby/
     environment:
@@ -28,10 +25,13 @@ services:
     volumes:
       - ./public:/home/public
     init: true
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1g
 
   mysql:
-    cpus: 1
-    mem_limit: 1g
     image: mysql/mysql-server:8.0
     environment:
       - "TZ=Asia/Tokyo"
@@ -43,6 +43,11 @@ services:
       - ./sql:/docker-entrypoint-initdb.d
     ports:
       - "3306:3306"
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1g
 
   memcached:
     image: memcached:1.6


### PR DESCRIPTION
# 変更点

- [Compose Specification](https://docs.docker.com/compose/compose-file/)に基づき
  - `services.*.cpus` から `deploy.limits.cpus` を指定するように変更した
  - `services.*.mem_limit` から `deploy.limits.memory` を指定するように変更した
  - [Deprecatedとなっている `version` 要素](https://docs.docker.com/compose/compose-file/#version-top-level-element)を削除した

## 変更の経緯

まずはじめに、実装を提供していただきありがとうございます。
ISUCON本を購入し、手元で練習しようとした時にこの問題を見つけました。

private-isuをDocker Composeで立ち上げたときの問題とその対策について共有します。

## 問題

https://github.com/catatsuy/private-isu#docker-compose
上記READMEで説明されている起動方法を元に、`docker compose up` コマンドを実行してコンテナを起動したのですが、
`docker-compose.yml` で期待されている、「使用するcpu数を制限する機能」が有効になっていないという問題が発生しました。

使用した[`docker-compose.yml`](https://github.com/catatsuy/private-isu/blob/master/webapp/docker-compose.yml) の概要を以下に示します。
```yaml
version: '2.2'                                                                                               
services: 
  ...
  app:
    cpus: 1 # コンテナが使用するCPUの上限を1に制限する
    mem_limit: 1g
  ...
  mysql:
    cpus: 1 # コンテナが使用するCPUの上限を1に制限する
    mem_limit: 1g
  ...
```

再現手順と確認方法は以下のとおりです
```bash
$ docker compose up -d
$ docker inspect webapp-mysql-1 | grep NanoCpus
            "NanoCpus": 0,   ## <= 想定している値は 1,000,000,000だが、0(無制限)になっている
```

## 調査

調査の結果、2つの問題を発見しました。

### 問題1: Compose V2は `cpus` 要素を受け取っていない

関連Issue: https://github.com/docker/compose/issues/9268

Service要素の中の `cpus` 要素を指定しても、起動するコンテナにはCPU数の制約がかかっていない、というissueを見つけました。

更に調査を勧めた結果、どうやら、[`cpus`パラメータは DEPRECATED](https://docs.docker.com/compose/compose-file/#cpus)となっていました。
Compose V2では、今後も対応しない可能性が高いと予想しています。
したがって、本PRでは、 [Compose Specification](https://docs.docker.com/compose/compose-file/)に沿うように `docker-compose.yml` を修正しました。

### 問題2: Compose V2 は `deploy.limits.cpus` を正しく処理しない

問題1を修正し、`docker compose up` コマンドにより再度コンテナを起動しました。
しかし、不正な設定値が反映されていることが判明しました。

問題2を調査した結果、現在の最新の[`docker/compose`](https://github.com/docker/compose)のリリースバージョン(v2.6.0)では、`deploy.limits.cpus`の値を正しく処理していないことが判明しました。
現在この問題に対する[修正PR](https://github.com/docker/compose/pull/9552)が上がっており、今後近い将来修正される可能性が高いと考えています。(当該PRの変更により、問題2が解決され、期待する動作になることを私のローカル環境で確認しました)

なお、Compose V2(`docker compose`)の代わりにCompose V1(`docker-compose`)を利用する場合、本PRの `docker-compose.yaml` を使用して期待する動作になることを確認済みです。
上記PRがマージされたバージョンがリリースされるまでは、`docker-compose` コマンドを利用する必要があります。

## まとめ

現在、private-isu のREADMEでは、Compose V2 を利用することが想定されています。
Compose V2を用いてコンテナを起動した場合、いくつかの問題が生じました。
それらの問題の対策について、以下のような想定をしています。

- 「問題1: Compose V2は `cpus` 要素を受け取っていない 」は、Compose V2で将来的に対応される可能性が低そう
- 「問題2: Compose V2 は `deploy.limits.cpus` を正しく処理しない」は、Compose V2で近い将来対応されそう

現状はCompose V1を利用し、問題2が修正された後にCompose V2を利用するのが良さそうだと考えています。

### 追記

`docker-compose.yml` の代わりに `compose.yml`,`compose.yaml` が推奨されるようになったようです
(今回は Compose V1 との互換性が求められているため本PRでは修正しませんでしたが、Compose V2 のみを利用する場合は`compose.yaml` に統一してもいいかもしれません)
参考link: https://docs.docker.com/compose/compose-file/#compose-file

### 追記2

PRに慣れておらず、間違った作法でPRを立てていたら申し訳ありません。
もし気になる箇所や誤っている箇所がある場合は、PRの変更内容に限らず、遠慮なくご指摘ください。