### PR TITLE
use bullseye

### DIFF
--- a/webapp/php/Dockerfile
+++ b/webapp/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.2-fpm-bullseye
 
 RUN apt update && apt install -y \
   unzip libmemcached-dev zlib1g-dev


### PR DESCRIPTION
refs: https://serverfault.com/questions/1134001/memcached-support-requires-libmemcached