### PR TITLE
Fix network settings in docker-compose.yml

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
   app:
     # Go実装の場合は golang/ PHP実装の場合は php/
-    build: php/
+    build: ruby/
     environment:
       ISUCONP_DB_HOST: mysql
       ISUCONP_DB_PORT: 3306

--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -12,7 +12,7 @@ services:
 
   app:
     # Go実装の場合は golang/ PHP実装の場合は php/
-    build: ruby/
+    build: php/
     environment:
       ISUCONP_DB_HOST: mysql
       ISUCONP_DB_PORT: 3306
@@ -53,6 +53,8 @@ services:
 
   memcached:
     image: memcached:1.6
+    networks:
+        - my_network
 
 volumes:
   mysql:


### PR DESCRIPTION
There was no setting of the network `my_network` memcached.
So, I add that.

After fix this, I confirmed the benchmarker worked for ruby/golang/php.


My Environment: MacBook Air (2020) M1 processor, 16 GB RAM, macOS Sonoma 14.2.1

Use OrbStack (v1.3.0) as docker engine.