### PR TITLE
remove dump.sql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          webapp/sql/dump.sql
+          webapp/sql/dump.sql.bz2
           benchmarker/userdata/img
         key: ${{ runner.os }}-make-init-${{ hashFiles('Makefile')}}
         restore-keys: |

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,9 @@
 .PHONY: init
-init: webapp/sql/dump.sql benchmarker/userdata/img
+init: webapp/sql/dump.sql.bz2 benchmarker/userdata/img
 
 webapp/sql/dump.sql.bz2:
 	cd webapp/sql && \
 	curl -L -O https://github.com/catatsuy/private-isu/releases/download/img/dump.sql.bz2
-
-webapp/sql/dump.sql: webapp/sql/dump.sql.bz2
-	cd webapp/sql && \
-	bunzip2 --keep --force dump.sql.bz2
 
 benchmarker/userdata/img.zip:
 	cd benchmarker/userdata && \

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ MySQLとmemcachedを起動した上で以下の手順を実行。
 * MySQLのrootユーザーのパスワードが設定されていない前提になっているので、設定されている場合は適宜読み替えること
 
 ```sh
-cat webapp/sql/dump.sql | mysql -uroot
+bunzip2 -c webapp/sql/dump.sql.bz2 | mysql -uroot
 
 cd webapp/ruby
 bundle install --path=vendor/bundle
@@ -136,7 +136,7 @@ make
 
 #### Docker Compose
 
-アプリケーションは以下の手順で実行できる。dump.sqlを配置しないとMySQLに初期データがimportされないので注意。
+アプリケーションは以下の手順で実行できる。dump.sql.bz2を配置しないとMySQLに初期データがimportされないので注意。
 
 ```sh
 cd webapp


### PR DESCRIPTION
MySQL docker image support bz2 files directly.
https://github.com/docker-library/mysql/commit/c96b0f7f58d48590d054952bc1e77d1f57d32452