### PR TITLE
Add purl binary for handling file replacements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,23 @@ jobs:
             echo "php_changes_detected=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Download purl
+        run: |
+          curl -sL https://github.com/catatsuy/purl/releases/latest/download/purl-linux-amd64.tar.gz | tar xz -C /tmp
+
+      - name: Move files to /usr/local/bin for purl
+        run: |
+          sudo mv /tmp/purl /usr/local/bin/
+
       - name: Update compose.yml if changes are detected
         if: steps.check-changes.outputs.go_changes_detected == 'true'
         run: |
-          sed -i 's|build: ruby/|build: golang/|' ./webapp/docker-compose.yml
+          purl -overwrite -replace '@build: ruby/@build: golang/@' ./webapp/docker-compose.yml
 
       - name: Update compose.yml if changes are detected
         if: steps.check-changes.outputs.php_changes_detected == 'true'
         run: |
-          perl -i -pe 's@build: (ruby|golang)/@build: php/@g' ./webapp/docker-compose.yml
+          purl -overwrite -replace '@build: (ruby|golang)/@build: php/@' ./webapp/docker-compose.yml
           mv webapp/etc/nginx/conf.d/default.conf webapp/etc/nginx/conf.d/default.conf.org
           mv webapp/etc/nginx/conf.d/php.conf.org webapp/etc/nginx/conf.d/php.conf
 


### PR DESCRIPTION
This pull request includes changes to the Continuous Integration (CI) workflow in the `.github/workflows/ci.yml` file. The main change is the introduction of `purl`, a command-line tool, to modify the `docker-compose.yml` file. This tool replaces previous usage of `sed` and `perl` for the same purpose. 

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR43-R59): Added steps to download and install `purl` in the CI environment. Also, replaced `sed` and `perl` commands with `purl` to modify the `docker-compose.yml` file when changes are detected. This change simplifies the CI workflow and makes it more readable.