### PR TITLE
Update PHP base image to version 8.1 in Dockerfile

### DIFF
--- a/webapp/php/Dockerfile
+++ b/webapp/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm-bookworm
+FROM php:8.1-fpm-bookworm
 
 RUN apt update && apt install -y \
   unzip libmemcached-dev zlib1g-dev libssl-dev


### PR DESCRIPTION
This pull request includes a change to the `webapp/php/Dockerfile` file. The PHP version used in the Docker image has been downgraded from `8.3` to `8.1`. This change might affect the compatibility of the web application with the Docker image.