### PR TITLE
Update go version to 1.22.2 and add go.mod for gofuzz v1.2.0

### DIFF
--- a/webapp/golang/go.mod
+++ b/webapp/golang/go.mod
@@ -1,6 +1,6 @@
 module github.com/catatsuy/private-isu/webapp/golang
 
-go 1.19
+go 1.22.2
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874

--- a/webapp/golang/go.sum
+++ b/webapp/golang/go.sum
@@ -9,6 +9,7 @@ github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNIT
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.2.2 h1:lqzMYz6bOfvn2WriPUjNByzeXIlVzURcPmgMczkmTjY=


### PR DESCRIPTION
This pull request includes a change to the `webapp/golang/go.mod` file. The Go version has been updated from `1.19` to `1.22.2`, which could potentially bring in new features, performance improvements, and bug fixes from the newer version of Go.