### PR TITLE
remove /etc/init.d

### DIFF
--- a/provisioning/image/ansible/03_nginx.yml
+++ b/provisioning/image/ansible/03_nginx.yml
@@ -21,4 +21,4 @@
       notify: reload nginx
   handlers:
     - name: reload nginx
-      shell: /usr/sbin/nginx -t && /etc/init.d/nginx reload
+      shell: /usr/sbin/nginx -t && systemctl reload nginx


### PR DESCRIPTION
This pull request includes a change to the `provisioning/image/ansible/03_nginx.yml` file. The change modifies the command used to reload the nginx server, switching from using `/etc/init.d/nginx reload` to `systemctl reload nginx`. This update reflects a more modern and recommended way to manage services in Linux.