### PR TITLE
Update Vagrant box to "ubuntu/jammy64" in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "ubuntu/jammy64"
   config.vm.box_check_update = false
 
   config.vm.network "private_network", type: "dhcp"


### PR DESCRIPTION
This pull request includes a minor change to the `Vagrantfile`. The change updates the virtual machine box from `ubuntu/focal64` to `ubuntu/jammy64`. This will affect the operating system environment in which the application is run during development and testing.