### PR TITLE
Add packageRules for docker nginx versioning in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,17 @@
       ]
     }
   ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "nginx"
+      ],
+      "versioning": "regex:^(?<major>[0-9]+)\\.(?<minor>[0-9]*[02468])(?<patch>\\d*)$"
+    }
+  ],
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"


### PR DESCRIPTION
This pull request includes a significant change to the `renovate.json` configuration file. The change introduces a new `packageRules` section that targets the Docker datasource and specifically the `nginx` package. The versioning rule for this package has been set to a regular expression that matches even minor versions.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R25-R35): Added a `packageRules` section that matches the Docker datasource and the `nginx` package. The versioning rule for this package uses a regular expression to match even minor versions.