### PR TITLE
Update README and manual for Ubuntu 24.04 and PHP 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,19 @@ $ /home/isucon/private_isu/benchmarker/bin/benchmarker -u /home/isucon/private_i
 
 以下のAMI IDで起動する。リージョンは『Asia Pacific (Tokyo)』。
 
-競技者用 (Ubuntu 22.04):
+競技者用 (Ubuntu 24.04):
 
 | 用途   |        AMI ID         |              AMI name               | 推奨インスタンスタイプ |
 | ------ | :-------------------: | :---------------------------------: | ---------------------- |
-| x86_64 | ami-0937f4bab7bea4382 | catatsuy_private_isu_amd64_20240323 | c7a.large              |
-| arm64  | ami-0b2a760e0651797cc | catatsuy_private_isu_arm64_20240323 | c7g.large              |
+| x86_64 | ami-047fdc2b851e73cad | catatsuy_private_isu_amd64_20240602 | c7a.large              |
+| arm64  | ami-0bed62bba4100a4b7 | catatsuy_private_isu_arm64_20240602 | c7g.large              |
 
-ベンチマーカー (Ubuntu 22.04):
+ベンチマーカー (Ubuntu 24.04):
 
 | 用途   |        AMI ID         |                 AMI name                  | 推奨インスタンスタイプ |
 | ------ | :-------------------: | :---------------------------------------: | ---------------------- |
-| x86_64 | ami-015450874c83c16e5 | catatsuy_private_isu_bench_amd64_20240323 | c7a.xlarge             |
-| arm64  | ami-024e477078b82c382 | catatsuy_private_isu_bench_arm64_20240323 | c7g.xlarge             |
+| x86_64 | ami-037be39355baf1f2e | catatsuy_private_isu_bench_amd64_20240602 | c7a.xlarge             |
+| arm64  | ami-034a457f6af55d65d | catatsuy_private_isu_bench_arm64_20240602 | c7g.xlarge             |
 
 
 ### 手元で動かす

--- a/manual.md
+++ b/manual.md
@@ -82,16 +82,16 @@ $ sudo systemctl disable isu-ruby
 $ sudo rm /etc/nginx/sites-enabled/isucon.conf
 $ sudo ln -s /etc/nginx/sites-available/isucon-php.conf /etc/nginx/sites-enabled/
 $ sudo systemctl reload nginx
-$ sudo systemctl start php8.1-fpm
-$ sudo systemctl enable php8.1-fpm
+$ sudo systemctl start php8.3-fpm
+$ sudo systemctl enable php8.3-fpm
 ```
 
-php-fpmの設定については、/etc/php/8.1/fpm/以下にあります。
+php-fpmの設定については、/etc/php/8.3/fpm/以下にあります。
 
 エラーなどの出力については、
 
 ```
-$ sudo journalctl -f -u php8.1-fpm
+$ sudo journalctl -f -u php8.3-fpm
 $ sudo tail -f /var/log/nginx/error.log
 ```
 


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `manual.md` files for system upgrades. The changes mainly involve updating Ubuntu versions and associated AMI IDs in the `README.md` file, and upgrading the PHP version in the `manual.md` file.

System upgrades:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R94): Updated the Ubuntu version from 22.04 to 24.04 and the associated AMI IDs for both x86_64 and arm64 instances.
* [`manual.md`](diffhunk://#diff-c5606b5d108d3562fa085b09df701f4c6472a58106d8414b0b2beaafbe82eeebL85-R94): Updated the PHP version from 8.1 to 8.3 in the system control commands and in the directory path for php-fpm settings.