### PR TITLE
Add build context and dockerfile for app service in docker-compose.yml

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -11,8 +11,13 @@ services:
       - my_network
 
   app:
-    # Go実装の場合は golang/ PHP実装の場合は php/
-    build: ruby/
+    build:
+      # Go実装の場合は golang/ PHP実装の場合は php/
+      context: ruby/
+      dockerfile: Dockerfile
+    depends_on:
+      - mysql
+      - memcached
     environment:
       ISUCONP_DB_HOST: mysql
       ISUCONP_DB_PORT: 3306


### PR DESCRIPTION
This pull request includes changes to the `webapp/docker-compose.yml` file to improve the configuration and dependencies of the `app` service.

Configuration improvements:

* Changed the `build` configuration to specify `context` and `dockerfile` for the `app` service. (`[webapp/docker-compose.ymlR14-R20](diffhunk://#diff-efc22b4e2c1265a4f8911655154a7825021feed9b3ed2b24cd00c5dc0d62b775R14-R20)`)

Dependency management:

* Added `depends_on` to ensure the `app` service waits for `mysql` and `memcached` to be available before starting. (`[webapp/docker-compose.ymlR14-R20](diffhunk://#diff-efc22b4e2c1265a4f8911655154a7825021feed9b3ed2b24cd00c5dc0d62b775R14-R20)`)