### PR TITLE
Optimize Dockerfile for caching and change CMD to ENTRYPOINT

### DIFF
--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -1,8 +1,10 @@
+#syntax=docker/dockerfile:1
 FROM ruby:3.3-slim
 
-RUN apt-get update -qq && apt-get install -y build-essential
-
-RUN apt-get install -y default-libmysqlclient-dev
+RUN \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update -qq && apt-get install -y build-essential default-libmysqlclient-dev
 
 RUN mkdir -p /home/webapp
 COPY Gemfile /home/webapp
@@ -11,4 +13,5 @@ WORKDIR /home/webapp
 RUN bundle config set --local path 'vendor/bundle'
 RUN bundle install
 COPY . /home/webapp
-CMD bundle exec foreman start
+
+ENTRYPOINT [ "bundle", "exec", "foreman", "start" ]


### PR DESCRIPTION
This pull request includes changes to the `webapp/ruby/Dockerfile` to improve Docker build efficiency and standardize the container startup process. The most important changes include optimizing the `apt-get` commands with caching and replacing the `CMD` instruction with `ENTRYPOINT`.

Dockerfile improvements:

* [`webapp/ruby/Dockerfile`](diffhunk://#diff-db9df8fe5c9eee88b83dd16cc569a178298d0bb466f9c931d974ddfa8965fb78R1-R7): Optimized `apt-get` commands using cache mounts to speed up subsequent builds.
* [`webapp/ruby/Dockerfile`](diffhunk://#diff-db9df8fe5c9eee88b83dd16cc569a178298d0bb466f9c931d974ddfa8965fb78L14-R17): Replaced `CMD` with `ENTRYPOINT` to ensure the container always runs the specified command.