### PR TITLE
Refactor Dockerfile to use multi-stage builds and add caching mechanisms

### DIFF
--- a/webapp/golang/Dockerfile
+++ b/webapp/golang/Dockerfile
@@ -1,12 +1,62 @@
-FROM golang:1.22
+# syntax=docker/dockerfile:1
 
-RUN mkdir -p /home/webapp
-WORKDIR /home/webapp
+FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+WORKDIR /src
 
-COPY go.mod /home/webapp/go.mod
-COPY go.sum /home/webapp/go.sum
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
 
-COPY . /home/webapp
-RUN go build -o app
-CMD ./app
+# This is the architecture you’re building for, which is passed in by the builder.
+# Placing it here allows the previous steps to be cached across architectures.
+ARG TARGETARCH
+
+# Build the application.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage a bind mount to the current directory to avoid having to copy the
+# source code into the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,target=. \
+  CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /bin/server .
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the alpine image as the foundation for running the app.
+# By specifying the "latest" tag, it will also use whatever happens to be the
+# most recent version of that image when you build your Dockerfile. If
+# reproducability is important, consider using a versioned tag
+# (e.g., alpine:3.17.2) or SHA (e.g., alpine@sha256:c41ab5c992deb4fe7e5da09f67a8804a46bd0592bfdf0b1847dde0e0889d2bff).
+FROM alpine:latest AS final
+
+# Install any runtime dependencies that are needed to run your application.
+# Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.
+RUN --mount=type=cache,target=/var/cache/apk \
+  apk --update add \
+  ca-certificates \
+  tzdata \
+  && \
+  update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "/nonexistent" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid "${UID}" \
+  appuser
+USER appuser
+
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/server /bin/
+
+# What the container should run when it is started.
+ENTRYPOINT [ "/bin/server" ]

--- a/webapp/golang/Dockerfile
+++ b/webapp/golang/Dockerfile
@@ -21,17 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /bin/server .
 
 ################################################################################
-# Create a new stage for running the application that contains the minimal
-# runtime dependencies for the application. This often uses a different base
-# image from the build stage where the necessary files are copied from the build
-# stage.
-#
-# The example below uses the alpine image as the foundation for running the app.
-# By specifying the "latest" tag, it will also use whatever happens to be the
-# most recent version of that image when you build your Dockerfile. If
-# reproducability is important, consider using a versioned tag
-# (e.g., alpine:3.17.2) or SHA (e.g., alpine@sha256:c41ab5c992deb4fe7e5da09f67a8804a46bd0592bfdf0b1847dde0e0889d2bff).
-FROM alpine:latest AS final
+FROM alpine:3.20 AS final
 
 # Install any runtime dependencies that are needed to run your application.
 # Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.


### PR DESCRIPTION
This pull request includes significant updates to the `Dockerfile` for the Golang web application. The changes improve build performance, add multi-stage builds, and enhance security by running the application as a non-privileged user.

### Dockerfile improvements:

* Changed the Dockerfile syntax to use `docker/dockerfile:1` for enhanced features and performance.
* Implemented multi-stage builds to separate the build environment from the runtime environment, improving security and reducing the final image size.
* Added `--mount` options for caching dependencies and binding source files, which speeds up the build process.
* Created a non-privileged user to run the application, following best practices for container security.
* Switched the base image for the runtime environment to `alpine:3.20` for a smaller, more secure final image.