### PR TITLE
Update Dockerfile to use build cache for apt package installation

### DIFF
--- a/webapp/php/Dockerfile
+++ b/webapp/php/Dockerfile
@@ -1,7 +1,10 @@
+# syntax=docker/dockerfile:1
 FROM php:8.3-fpm-bookworm
 
-RUN apt update && apt install -y \
-  unzip libmemcached-dev zlib1g-dev libssl-dev
+RUN \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update -qq && apt-get install -y unzip libmemcached-dev zlib1g-dev libssl-dev
 
 RUN docker-php-ext-install pdo pdo_mysql
 


### PR DESCRIPTION
This pull request includes changes to the `webapp/php/Dockerfile` to improve the efficiency of the Docker build process by leveraging build cache mounts.

Improvements to Docker build process:

* [`webapp/php/Dockerfile`](diffhunk://#diff-42a8186e21d6bfb187d73897fc2dcc933abf2f50594e3b0c2ad3da1a5f1cb449R1-R7): Added build cache mounts for `apt` package manager to speed up the `apt-get update` and `apt-get install` commands.