### PR TITLE
Update benchmarker path in CI and README, improve Dockerfile and run.sh.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         continue-on-error: true
         run: |
           cd benchmarker
-          docker run --network host --add-host host.docker.internal:host-gateway -i private-isu-benchmarker /opt/go/bin/benchmarker -t http://host.docker.internal -u /opt/go/userdata || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+          docker run --network host --add-host host.docker.internal:host-gateway -i private-isu-benchmarker /bin/benchmarker -t http://host.docker.internal -u /opt/userdata || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
 
       - name: Show logs
         run: |

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ mv nginx/conf.d/php.conf.org nginx/conf.d/php.conf
 ```sh
 cd benchmarker
 docker build -t private-isu-benchmarker .
-docker run --network host -i private-isu-benchmarker /opt/go/bin/benchmarker -t http://host.docker.internal -u /opt/go/userdata
+docker run --network host -i private-isu-benchmarker /bin/benchmarker -t http://host.docker.internal -u /opt/userdata
 # Linuxの場合
-docker run --network host --add-host host.docker.internal:host-gateway -i private-isu-benchmarker /opt/go/bin/benchmarker -t http://host.docker.internal -u /opt/go/userdata
+docker run --network host --add-host host.docker.internal:host-gateway -i private-isu-benchmarker /bin/benchmarker -t http://host.docker.internal -u /opt/userdata
 ```
 
 動かない場合は`ip a`してdocker0のインタフェースでホストのIPアドレスを調べて`host.docker.internal`の代わりに指定する。以下の場合は`172.17.0.1`を指定する。

--- a/benchmarker/Dockerfile
+++ b/benchmarker/Dockerfile
@@ -1,8 +1,55 @@
-FROM golang:1.22
+# syntax=docker/dockerfile:1
 
-RUN mkdir -p /opt/go
-COPY . /opt/go
-WORKDIR /opt/go
-RUN go build -o bin/benchmarker
+FROM --platform=$BUILDPLATFORM golang:1.22 AS build
+WORKDIR /src
 
-ENTRYPOINT ["/opt/go/run.sh"]
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
+
+# This is the architecture you’re building for, which is passed in by the builder.
+# Placing it here allows the previous steps to be cached across architectures.
+ARG TARGETARCH
+
+# Build the application.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage a bind mount to the current directory to avoid having to copy the
+# source code into the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,target=. \
+  CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /bin/benchmarker .
+
+################################################################################
+FROM alpine:3.20 AS final
+
+# Install any runtime dependencies that are needed to run your application.
+# Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.
+RUN --mount=type=cache,target=/var/cache/apk \
+  apk --update add \
+  ca-certificates \
+  tzdata \
+  && \
+  update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "/nonexistent" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid "${UID}" \
+  appuser
+USER appuser
+
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/benchmarker /bin/
+
+COPY run.sh /opt/
+COPY userdata /opt/userdata
+
+# What the container should run when it is started.
+ENTRYPOINT [ "/opt/run.sh" ]

--- a/benchmarker/run.sh
+++ b/benchmarker/run.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 exec "$@"


### PR DESCRIPTION
This pull request includes several updates to the benchmarking setup, Dockerfile, and related scripts to improve the build process and runtime environment. The most important changes are grouped into Dockerfile improvements and script adjustments.

### Dockerfile improvements:

* Updated `benchmarker/Dockerfile` to use a multi-stage build process, leveraging cache mounts and bind mounts to speed up builds and support multiple architectures. This also includes switching the base image to `alpine:3.20` for the final stage and creating a non-privileged user for running the application.

### Script adjustments:

* Changed the shebang in `benchmarker/run.sh` from `#!/bin/bash` to `#!/bin/sh` to ensure compatibility with the Alpine base image.

### Benchmarking commands updates:

* Updated the `docker run` commands in `.github/workflows/ci.yml` and `README.md` to reflect the new location of the `benchmarker` executable (`/bin/benchmarker`) and the updated user data path (`/opt/userdata`). [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL94-R94) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L161-R163)