### PR TITLE
fix(ci): update placeholders from '@build' to '@context' in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,12 @@ jobs:
       - name: Update compose.yml if changes are detected
         if: steps.check-changes.outputs.go_changes_detected == 'true'
         run: |
-          purl -overwrite -replace '@build: ruby/@build: golang/@' ./webapp/docker-compose.yml
+          purl -overwrite -replace '@context: ruby/@context: golang/@' ./webapp/docker-compose.yml
 
       - name: Update compose.yml if changes are detected
         if: steps.check-changes.outputs.php_changes_detected == 'true'
         run: |
-          purl -overwrite -replace '@build: (ruby|golang)/@build: php/@' ./webapp/docker-compose.yml
+          purl -overwrite -replace '@context: (ruby|golang)/@context: php/@' ./webapp/docker-compose.yml
           mv webapp/etc/nginx/conf.d/default.conf webapp/etc/nginx/conf.d/default.conf.org
           mv webapp/etc/nginx/conf.d/php.conf.org webapp/etc/nginx/conf.d/php.conf
 


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/ci.yml` file to update the `purl` command used for modifying the `docker-compose.yml` file. The changes ensure that the correct context is replaced in the `docker-compose.yml` file when changes are detected in specific languages.

Key changes:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL54-R59): Updated the `purl` command to replace `@context: ruby/@context: golang/@` instead of `@build: ruby/@build: golang/@` and `@context: (ruby|golang)/@context: php/@` instead of `@build: (ruby|golang)/@build: php/@` when changes are detected.