### PR TITLE
Update purl command to include -fail option in CI workflow steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,12 @@ jobs:
       - name: Update compose.yml if changes are detected
         if: steps.check-changes.outputs.go_changes_detected == 'true'
         run: |
-          purl -overwrite -replace '@context: ruby/@context: golang/@' ./webapp/docker-compose.yml
+          purl -fail -overwrite -replace '@context: ruby/@context: golang/@' ./webapp/docker-compose.yml
 
       - name: Update compose.yml if changes are detected
         if: steps.check-changes.outputs.php_changes_detected == 'true'
         run: |
-          purl -overwrite -replace '@context: (ruby|golang)/@context: php/@' ./webapp/docker-compose.yml
+          purl -fail -overwrite -replace '@context: (ruby|golang)/@context: php/@' ./webapp/docker-compose.yml
           mv webapp/etc/nginx/conf.d/default.conf webapp/etc/nginx/conf.d/default.conf.org
           mv webapp/etc/nginx/conf.d/php.conf.org webapp/etc/nginx/conf.d/php.conf
 


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/ci.yml` file. The change ensures that the `purl` command will fail if it encounters an error during the replacement process, improving the reliability of the CI workflow.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL54-R59): Added the `-fail` option to the `purl` command to ensure it fails on errors during the replacement process.