### PR TITLE
Change base image to Debian, and add templates

### DIFF
--- a/webapp/golang/Dockerfile
+++ b/webapp/golang/Dockerfile
@@ -21,16 +21,12 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
   CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /bin/server .
 
 ################################################################################
-FROM alpine:3.20 AS final
+FROM debian:bookworm-slim AS final
 
-# Install any runtime dependencies that are needed to run your application.
-# Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.
-RUN --mount=type=cache,target=/var/cache/apk \
-  apk --update add \
-  ca-certificates \
-  tzdata \
-  && \
-  update-ca-certificates
+RUN \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  apt-get update -qq && apt-get install -y openssl
 
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/go/dockerfile-user-best-practices/
@@ -45,8 +41,11 @@ RUN adduser \
   appuser
 USER appuser
 
+WORKDIR /home/webapp
+
 # Copy the executable from the "build" stage.
 COPY --from=build /bin/server /bin/
+COPY ./templates ./templates
 
 # What the container should run when it is started.
 ENTRYPOINT [ "/bin/server" ]


### PR DESCRIPTION
This pull request includes several changes to the `webapp/golang/Dockerfile` to update the base image and improve the build process. The most important changes include switching the base image from Alpine to Debian and updating the cache mount points for package management.

Base image update:

* [`webapp/golang/Dockerfile`](diffhunk://#diff-5d4bb336edf57f32f457dae4bca03f7d54ce4ca0831f88637686a94ffc437496L24-R29): Changed the base image from `alpine:3.20` to `debian:bookworm-slim` to leverage Debian's package management system.

Package management improvements:

* [`webapp/golang/Dockerfile`](diffhunk://#diff-5d4bb336edf57f32f457dae4bca03f7d54ce4ca0831f88637686a94ffc437496L24-R29): Updated the cache mount points to `/var/lib/apt` and `/var/cache/apt` for Debian's `apt-get` package manager, and installed `openssl` as a runtime dependency.

Additional changes:

* [`webapp/golang/Dockerfile`](diffhunk://#diff-5d4bb336edf57f32f457dae4bca03f7d54ce4ca0831f88637686a94ffc437496R44-R48): Added `WORKDIR /home/webapp` to set the working directory for the application.
* [`webapp/golang/Dockerfile`](diffhunk://#diff-5d4bb336edf57f32f457dae4bca03f7d54ce4ca0831f88637686a94ffc437496R44-R48): Copied the `./templates` directory into the Docker image to ensure necessary templates are available at runtime.