### PR TITLE
Optimize tables before running benchmarks on database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,10 @@ jobs:
             echo "Waiting for database initialization..."
             sleep 10
           done
-          sleep 10
+          # for avoiding "Lock wait timeout exceeded; try restarting transaction" error
+          docker compose exec -T mysql mysql -uroot -proot -e "OPTIMIZE table posts;" isuconp
+          docker compose exec -T mysql mysql -uroot -proot -e "OPTIMIZE table users;" isuconp
+          docker compose exec -T mysql mysql -uroot -proot -e "OPTIMIZE table comments;" isuconp
 
       - name: Run the benchmark
         continue-on-error: true


### PR DESCRIPTION
This pull request includes an important change to the CI workflow configuration to optimize database tables and avoid a common error. 

CI workflow improvements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL88-R91): Added commands to optimize `posts`, `users`, and `comments` tables to avoid the "Lock wait timeout exceeded; try restarting transaction" error.