### PR TITLE
Update CI workflow to save benchmark output and check results with jq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,11 @@ jobs:
         continue-on-error: true
         run: |
           cd benchmarker
-          docker run --network host --add-host host.docker.internal:host-gateway -i private-isu-benchmarker /bin/benchmarker -t http://host.docker.internal -u /opt/userdata || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+          docker run --network host --add-host host.docker.internal:host-gateway -i private-isu-benchmarker /bin/benchmarker -t http://host.docker.internal -u /opt/userdata | tee benchmark_output.json || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+
+      - name: Check benchmark result
+        run: |
+          cat benchmark_output.json | jq '.pass' | grep false && echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV || true
 
       - name: Show logs
         run: |


### PR DESCRIPTION
This pull request updates the CI workflow to capture and check benchmark results more effectively. The most important changes include modifying the benchmark command to save the output to a JSON file and adding a step to check the benchmark result.

Changes to CI workflow:

* Modified the benchmark command to save the output to a `benchmark_output.json` file. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlL97-R101](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL97-R101))
* Added a step to check the benchmark result by parsing the `benchmark_output.json` file and setting the `BENCHMARK_FAILED` environment variable if the benchmark did not pass. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlL97-R101](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL97-R101))