### PR TITLE
Remove unnecessary database optimization commands from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,6 @@ jobs:
             echo "Waiting for database initialization..."
             sleep 10
           done
-          # for avoiding "Lock wait timeout exceeded; try restarting transaction" error
-          docker compose exec -T mysql mysql -uroot -proot -e "OPTIMIZE table posts;" isuconp
-          docker compose exec -T mysql mysql -uroot -proot -e "OPTIMIZE table users;" isuconp
-          docker compose exec -T mysql mysql -uroot -proot -e "OPTIMIZE table comments;" isuconp
 
       - name: Run the benchmark
         continue-on-error: true


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/ci.yml` file to simplify the CI workflow by removing unnecessary database optimization commands.

* Simplified CI workflow by removing the database optimization commands for the `posts`, `users`, and `comments` tables in the `jobs:` section of `.github/workflows/ci.yml`. (`[.github/workflows/ci.ymlL88-L91](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL88-L91)`)