### PR TITLE
Change directory to benchmarker before checking benchmark result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,15 @@ jobs:
 
       - name: Check benchmark result
         run: |
-          cat benchmark_output.json | jq '.pass' | grep false && echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV || true
+          cd benchmarker
+          if [ ! -f benchmark_output.json ]; then
+            echo "benchmark_output.json not found"
+            exit 1
+          fi
+          if ! jq -e '.pass == true' benchmark_output.json > /dev/null; then
+            echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+            exit 1
+          fi
 
       - name: Show logs
         run: |


### PR DESCRIPTION
This pull request includes a small change to the CI workflow configuration file `.github/workflows/ci.yml`. The change ensures that the `Check benchmark result` step is executed from the correct directory.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL101-R102): Modified the `Check benchmark result` step to change to the `benchmarker` directory before running the command.