### PR TITLE
Refactor image and post link extraction to use iter

### DIFF
--- a/benchmarker/Makefile
+++ b/benchmarker/Makefile
@@ -1,4 +1,4 @@
 all: bin/benchmarker
 
-bin/benchmarker: *.go checker/*.go
+bin/benchmarker: *.go checker/*.go go.mod go.sum
 	go build -o bin/benchmarker

--- a/benchmarker/scenario.go
+++ b/benchmarker/scenario.go
@@ -34,25 +34,25 @@ func loadImages(s *checker.Session, imageURLs []string) {
 }
 
 func extractImages(doc *goquery.Document) []string {
-	imageURLs := []string{}
+	imageURLs := make([]string, 0, PostsPerPage)
 
-	doc.Find("img.isu-image").Each(func(_ int, selection *goquery.Selection) {
-		if url, ok := selection.Attr("src"); ok {
+	for _, el := range doc.Find("img.isu-image").EachIter() {
+		if url, ok := el.Attr("src"); ok {
 			imageURLs = append(imageURLs, url)
 		}
-	}).Length()
+	}
 
 	return imageURLs
 }
 
 func extractPostLinks(doc *goquery.Document) []string {
-	postLinks := []string{}
+	postLinks := make([]string, 0, PostsPerPage)
 
-	doc.Find("a.isu-post-permalink").Each(func(_ int, selection *goquery.Selection) {
-		if url, ok := selection.Attr("href"); ok {
+	for _, el := range doc.Find("a.isu-post-permalink").EachIter() {
+		if url, ok := el.Attr("href"); ok {
 			postLinks = append(postLinks, url)
 		}
-	}).Length()
+	}
 
 	return postLinks
 }


### PR DESCRIPTION
This pull request includes changes to the `benchmarker` module, focusing on improving the build process and optimizing image and post link extraction. The most important changes are as follows:

Build process improvements:

* [`benchmarker/Makefile`](diffhunk://#diff-bbc931da6c4344653a8a4330cb141198e1041007379a554a4cc9afcdd7ce5b78L3-R3): Updated the build target `bin/benchmarker` to include `go.mod` and `go.sum` files, ensuring all dependencies are considered during the build process.

Code optimization:

* [`benchmarker/scenario.go`](diffhunk://#diff-eb72fea867f2686b0a6a11d164ea50562e2072cde76642386c662c71d6c04e1cL37-R55): Optimized the `extractImages` and `extractPostLinks` functions by preallocating slices with a capacity of `PostsPerPage` and replacing the `.Each` method with `.EachIter` for better performance.