### PR TITLE
Remove toolchain version from go.mod

### DIFF
--- a/webapp/golang/go.mod
+++ b/webapp/golang/go.mod
@@ -2,8 +2,6 @@ module github.com/catatsuy/private-isu/webapp/golang
 
 go 1.23
 
-toolchain go1.23.0
-
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/bradleypeabody/gorilla-sessions-memcache v0.0.0-20181103040241-659414f458e1


### PR DESCRIPTION
This pull request includes a small change to the `webapp/golang/go.mod` file. The change removes the `toolchain go1.23.0` line, which is no longer necessary.

* [`webapp/golang/go.mod`](diffhunk://#diff-52044a3cca91cb2ffbe4b7024efd2814acfeb9d469be4d7a81e0528e3b6f0714L5-L6): Removed the `toolchain go1.23.0` line.