### PR TITLE
#552 の解消 (`Install Composer`の失敗)

### DIFF
--- a/provisioning/image/ansible/07_application.yml
+++ b/provisioning/image/ansible/07_application.yml
@@ -37,6 +37,8 @@
         - composer
 
     - name: Install Composer
+      environment:
+        HOME: /home/isucon
       shell: php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
       when: "'Installer verified' in composer_setup_verify.stdout"
       tags:


### PR DESCRIPTION
Ansibleから起動した際に `Install Composer` が失敗してしまう問題が存在していた (#552)

`HOME` 環境変数を追加することで解消。