### PR TITLE
Update PHP version in Dockerfile to 8.4-fpm from 8.3-fpm-bookworm

### DIFF
--- a/webapp/php/Dockerfile
+++ b/webapp/php/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM php:8.3-fpm-bookworm
+FROM php:8.4-fpm
 
 RUN \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \


### PR DESCRIPTION
This pull request includes an update to the `webapp/php/Dockerfile` to upgrade the PHP version used in the Docker image.

* [`webapp/php/Dockerfile`](diffhunk://#diff-42a8186e21d6bfb187d73897fc2dcc933abf2f50594e3b0c2ad3da1a5f1cb449L2-R2): Updated the PHP version from `8.3-fpm-bookworm` to `8.4-fpm`.