### PR TITLE
Add step to show logs in CI workflow after the benchmarking process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
           cd benchmarker
           docker run --network host --add-host host.docker.internal:host-gateway -i private-isu-benchmarker /bin/benchmarker -t http://host.docker.internal -u /opt/userdata | tee benchmark_output.json || echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
 
+      - name: Show logs
+        run: |
+          cd webapp
+          docker compose logs
+
       - name: Check benchmark result
         run: |
           cd benchmarker
@@ -103,11 +108,6 @@ jobs:
             echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
             exit 1
           fi
-
-      - name: Show logs
-        run: |
-          cd webapp
-          docker compose logs
 
       - name: Fail if benchmark failed
         if: env.BENCHMARK_FAILED == 'true'


### PR DESCRIPTION
This pull request includes a small change to the CI workflow configuration file `.github/workflows/ci.yml`. The change reorders the steps to show logs before checking the benchmark result.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR95-R99): Moved the "Show logs" step to occur before the "Check benchmark result" step. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR95-R99) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL107-L111)