### PR TITLE
Add app dependency to nginx service in docker-compose.yml

### DIFF
--- a/webapp/docker-compose.yml
+++ b/webapp/docker-compose.yml
@@ -2,6 +2,8 @@ name: private-isu
 services:
   nginx:
     image: nginx:1.26
+    depends_on:
+      - app
     volumes:
       - ./etc/nginx/conf.d:/etc/nginx/conf.d
       - ./public:/public


### PR DESCRIPTION
This pull request includes a small change to the `webapp/docker-compose.yml` file. The change ensures that the `nginx` service depends on the `app` service, improving service startup order.

* [`webapp/docker-compose.yml`](diffhunk://#diff-efc22b4e2c1265a4f8911655154a7825021feed9b3ed2b24cd00c5dc0d62b775R5-R6): Added `depends_on` directive to ensure `nginx` service waits for the `app` service to start.