### PR TITLE
Upgrade Ruby version from 3.3-slim to 3.4-slim in Dockerfile

### DIFF
--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1
-FROM ruby:3.3-slim
+FROM ruby:3.4-slim
 
 RUN \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/webapp/ruby/Gemfile
+++ b/webapp/ruby/Gemfile
@@ -6,6 +6,7 @@ gem "sinatra-contrib"
 gem "rack"
 gem "foreman"
 gem "unicorn"
+gem 'bigdecimal'
 gem "mysql2"
 gem "rack-flash3"
 gem 'connection_pool'


### PR DESCRIPTION
This pull request includes updates to the Dockerfile and Gemfile for the Ruby web application. The most important changes include upgrading the Ruby version and adding a new gem dependency.

Dockerfile update:

* [`webapp/ruby/Dockerfile`](diffhunk://#diff-db9df8fe5c9eee88b83dd16cc569a178298d0bb466f9c931d974ddfa8965fb78L2-R2): Upgraded the base image from Ruby 3.3-slim to Ruby 3.4-slim.

Gemfile update:

* [`webapp/ruby/Gemfile`](diffhunk://#diff-6e19613ea91322b3a139158112bbd60589297610206a95c0d56abfc51ed47e67R9): Added the `bigdecimal` gem to the list of dependencies.