### PR TITLE
Update CI workflow to improve error message for benchmark failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
             exit 1
           fi
           if ! jq -e '.pass == true' benchmark_output.json > /dev/null; then
-            echo "BENCHMARK_FAILED=true" >> $GITHUB_ENV
+            echo "Benchmark failed: pass is not true"
             exit 1
           fi
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change modifies the handling of benchmark failures to provide a clearer error message when the benchmark does not pass.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL118-R118): Changed the output message when the benchmark fails from setting an environment variable to printing a more descriptive error message.