### PR TITLE
Update Go version to 1.23.0 for CodeQL

### DIFF
--- a/benchmarker/go.mod
+++ b/benchmarker/go.mod
@@ -1,6 +1,6 @@
 module github.com/catatsuy/private-isu/benchmarker
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.2

--- a/webapp/golang/go.mod
+++ b/webapp/golang/go.mod
@@ -1,6 +1,6 @@
 module github.com/catatsuy/private-isu/webapp/golang
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874


### PR DESCRIPTION
This pull request includes minor changes to the `go.mod` files in both the `benchmarker` and `webapp/golang` modules. The changes update the Go version specification from `go 1.23` to `go 1.23.0`.

Changes to `go.mod` files:

* [`benchmarker/go.mod`](diffhunk://#diff-f8b5c8bcf2213e5e3113a96d7d5803320dce62db5f2342c5606cd27644b86338L3-R3): Updated the Go version specification from `go 1.23` to `go 1.23.0`.
* [`webapp/golang/go.mod`](diffhunk://#diff-52044a3cca91cb2ffbe4b7024efd2814acfeb9d469be4d7a81e0528e3b6f0714L3-R3): Updated the Go version specification from `go 1.23` to `go 1.23.0`.