### PR TITLE
Add CODEOWNERS file for webapp/python/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+webapp/python/ @kyoto7250


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns the `webapp/python/` directory to the user `@kyoto7250` for ownership.