### PR TITLE
refactor: remove unnecessary endif

### DIFF
--- a/webapp/ruby/app.rb
+++ b/webapp/ruby/app.rb
@@ -63,8 +63,6 @@ module Isuconp
 
         if user && calculate_passhash(user[:account_name], password) == user[:passhash]
           return user
-        elsif user
-          return nil
         else
           return nil
         end


### PR DESCRIPTION
ruby 実装のログイン処理の不要な `elsif` 分岐を削除します。

コードが実装された当初はここに処理が入る想定だったように見えますが、
現状活用されていないので削除をするで問題ないかと思います。

コードが追加されたコミット
https://github.com/catatsuy/private-isu/commit/4f87beaa4777110c2e39577ea91ec2af74a2e01