### PR TITLE
update Go version from 1.22.x to 1.24.1 in codeql.yml workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.24.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/codeql.yml` file. The change updates the Go version used in the setup from `1.22.x` to `1.24.1`.