### PR TITLE
Refactor: Replace for loops with range in several places

### DIFF
--- a/benchmarker/cli.go
+++ b/benchmarker/cli.go
@@ -220,7 +220,7 @@ func outputNeedToContactUs(message string) {
 
 func makeChanBool(len int) chan bool {
 	ch := make(chan bool, len)
-	for i := 0; i < len; i++ {
+	for range len {
 		ch <- true
 	}
 	return ch

--- a/benchmarker/util/util.go
+++ b/benchmarker/util/util.go
@@ -33,7 +33,7 @@ func RandomLUNStr(n int) string {
 
 func randomStr(n int, s []rune) string {
 	buf := make([]byte, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		buf[i] = byte(s[mrand.IntN(len(s))])
 	}
 	return string(buf)


### PR DESCRIPTION
This pull request includes several changes to improve the readability and efficiency of loops and to simplify the codebase by using the `slices` package. The most important changes include modifying loop constructs to use the `range` keyword and replacing manual iteration with `slices.Contains`.

Improvements to loop constructs:

* [`benchmarker/cli.go`](diffhunk://#diff-33713012423aa158ce9ab46253588e6745b5df0d51940c02656f0338737d4489L223-R223): Changed the loop in `makeChanBool` function to use `range` instead of an index-based loop.
* [`benchmarker/scenario.go`](diffhunk://#diff-eb72fea867f2686b0a6a11d164ea50562e2072cde76642386c662c71d6c04e1cL106-R107): Modified loops in `indexMoreAndMoreScenario`, `loadIndexScenario`, and `randomStr` functions to use `range` instead of an index-based loop. [[1]](diffhunk://#diff-eb72fea867f2686b0a6a11d164ea50562e2072cde76642386c662c71d6c04e1cL106-R107) [[2]](diffhunk://#diff-eb72fea867f2686b0a6a11d164ea50562e2072cde76642386c662c71d6c04e1cL152-R153) [[3]](diffhunk://#diff-17cc90b62c9929ca8d1cf75505156ea325a717e6780b97fa5717d98e2ee2dc36L36-R36)

Codebase simplification:

* [`benchmarker/scenario.go`](diffhunk://#diff-eb72fea867f2686b0a6a11d164ea50562e2072cde76642386c662c71d6c04e1cL553-L557): Replaced manual iteration with `slices.Contains` in `banScenario` function to check for the presence of an image URL in a list. [[1]](diffhunk://#diff-eb72fea867f2686b0a6a11d164ea50562e2072cde76642386c662c71d6c04e1cL553-L557) [[2]](diffhunk://#diff-eb72fea867f2686b0a6a11d164ea50562e2072cde76642386c662c71d6c04e1cL600-L604)

Dependency updates:

* [`benchmarker/scenario.go`](diffhunk://#diff-eb72fea867f2686b0a6a11d164ea50562e2072cde76642386c662c71d6c04e1cR14): Added the `slices` package to the import statements.