### PR TITLE
Add Python to supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Ubuntu 24.04
 
 ## 起動方法
 
-* Ruby/Go/PHPの3言語が用意されており、デフォルトはRubyが起動する
+* Ruby/Go/PHP/Pythonの4言語が用意されており、デフォルトはRubyが起動する
   * Node.jsは現状メンテナンスされていない
   * AMI・Vagrantで他の言語の実装を動かす場合は[manual.md](/manual.md)を参考にする
 * AMI・Docker Compose・Vagrantが用意されている
@@ -228,7 +228,5 @@ https://gist.github.com/tohutohu/024551682a9004da286b0abd6366fa55 を参照
 
 ## 他の言語実装
 
-* Python実装 https://github.com/methane/pixiv-isucon2016-python
-  * provisioning code https://github.com/x-tech5/aws-isucon-book-tutorial
 * Rust実装 https://github.com/Romira915/private-isu-rust
 * Scala実装 https://github.com/catatsuy/private-isu/pull/140


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect changes in language support and removes outdated references to a Python implementation. 

Updates to language support:

* Updated the list of supported languages to include Python, increasing the total to four languages (Ruby, Go, PHP, and Python), with Ruby remaining the default.

Removal of outdated references:

* Removed the mention of a Python implementation and its associated provisioning code, as these are no longer relevant.