### PR TITLE
serve static files using os.Root for better file handling

### DIFF
--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -829,6 +829,12 @@ func main() {
 	}
 	defer db.Close()
 
+	root, err := os.OpenRoot("../public")
+	if err != nil {
+		log.Fatalf("failed to open root: %v", err)
+	}
+	defer root.Close()
+
 	r := chi.NewRouter()
 
 	r.Get("/initialize", getInitialize)
@@ -847,7 +853,7 @@ func main() {
 	r.Post("/admin/banned", postAdminBanned)
 	r.Get(`/@{accountName:[a-zA-Z]+}`, getAccountName)
 	r.Get("/*", func(w http.ResponseWriter, r *http.Request) {
-		http.FileServer(http.Dir("../public")).ServeHTTP(w, r)
+		http.FileServerFS(root.FS()).ServeHTTP(w, r)
 	})
 
 	log.Fatal(http.ListenAndServe(":8080", r))


### PR DESCRIPTION
This pull request updates the file handling in the `main` function of `webapp/golang/app.go` to improve resource management and simplify serving static files. The most important changes involve introducing a `root` directory handler and replacing the static file server implementation.

### File Handling Improvements:
* Added initialization of `root` using `os.OpenRoot("../public")` to handle the root directory for serving static files. Included error handling and ensured the resource is properly closed with `defer`.

### Static File Server Update:
* Replaced `http.FileServer(http.Dir("../public"))` with `http.FileServerFS(root.FS())` to utilize the newly introduced `root` directory handler for serving static files.