### PR TITLE
refactor loops and slice creation for idiomatic Go code style

### DIFF
--- a/webapp/golang/app.go
+++ b/webapp/golang/app.go
@@ -190,7 +190,7 @@ func makePosts(results []Post, csrfToken string, allComments bool) ([]Post, erro
 			return nil, err
 		}
 
-		for i := 0; i < len(comments); i++ {
+		for i := range comments {
 			err := db.Get(&comments[i].User, "SELECT * FROM `users` WHERE `id` = ?", comments[i].UserID)
 			if err != nil {
 				return nil, err
@@ -467,8 +467,8 @@ func getAccountName(w http.ResponseWriter, r *http.Request) {
 		}
 		placeholder := strings.Join(s, ", ")
 
-		// convert []int -> []interface{}
-		args := make([]interface{}, len(postIDs))
+		// convert []int -> []any
+		args := make([]any, len(postIDs))
 		for i, v := range postIDs {
 			args[i] = v
 		}


### PR DESCRIPTION
This pull request makes two small changes in the `webapp/golang/app.go` file to improve code readability and modernize the syntax. 

Code readability and modernization:

* Updated the `for` loop in the `makePosts` function to use the `range` keyword directly for better readability. (`[webapp/golang/app.goL193-R193](diffhunk://#diff-7fd5e18e2f628f9339bef0c2b540b653031f2c48e8baa324553439eea82324e7L193-R193)`)
* Replaced the `interface{}` type with the more modern `any` type when converting a slice of integers to a slice of interfaces in the `getAccountName` function. (`[webapp/golang/app.goL471-R471](diffhunk://#diff-7fd5e18e2f628f9339bef0c2b540b653031f2c48e8baa324553439eea82324e7L471-R471)`)