### PR TITLE
Update manual with clarifications

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -33,7 +33,7 @@ EC2インスタンスのパブリックIPアドレスにブラウザでアクセ
 
 ### 4. 負荷走行を実行
 
-この操作後、ポータルにて、あなたのチームのスコアが反映されているか確認して下さい。
+この操作後、ポータルにて、あなたのチームのスコアが反映されているか確認して下さい。負荷走行を実行すると、あなたのアプリケーションに対して自動的にリクエストが送信され、その結果がポータルサイトのスコアに反映されます。スコアの反映には数分かかる場合があります。
 
 ### ディレクトリ構成
 
@@ -50,7 +50,7 @@ EC2インスタンスのパブリックIPアドレスにブラウザでアクセ
 
 ### 参考実装の言語切り替え方法
 
-参考実装の言語はRuby/PHP/Goが用意されており、初期状態ではRubyの実装が起動しています。
+初期状態ではRubyによる参考実装が起動しています。これをベースに最適化を進めるか、必要に応じてPHP、Go、またはPythonの参考実装に切り替えることができます。一度に起動できるアプリケーション言語は1つだけです。基本的な切り替え手順は、現在動作しているRubyのサービス(`isu-ruby`)を停止・無効化し、その後、目的の言語のサービスを起動・有効化します。PHPへ切り替える場合、またはPHPからRubyへ戻す場合は、Nginxの設定変更も伴います。
 
 80番ポートでアクセスできるので、ブラウザから動作確認をすることができます。
 
@@ -58,7 +58,7 @@ EC2インスタンスのパブリックIPアドレスにブラウザでアクセ
 
 エラーなどの出力については、
 
-```
+```bash
 $ sudo journalctl -f -u isu-ruby
 ```
 
@@ -66,44 +66,53 @@ $ sudo journalctl -f -u isu-ruby
 
 また、unicornの再起動は、
 
-```
+```bash
 $ sudo systemctl restart isu-ruby
 ```
 
 などですることができます。
 
-#### PHPへの切り替え方
+#### PHP (php8.3-fpm) への切り替え方
 
-起動する実装をPHPに切り替えるには、以下の操作を行います。
+Ruby実装からPHP実装に切り替えるには、以下の操作を行います。まず、Rubyサービスを停止・無効化します:
 
-```
+```bash
 $ sudo systemctl stop isu-ruby
 $ sudo systemctl disable isu-ruby
+```
+
+```bash
 $ sudo rm /etc/nginx/sites-enabled/isucon.conf
 $ sudo ln -s /etc/nginx/sites-available/isucon-php.conf /etc/nginx/sites-enabled/
 $ sudo systemctl reload nginx
+```
+
+```bash
 $ sudo systemctl start php8.3-fpm
 $ sudo systemctl enable php8.3-fpm
 ```
 
-php-fpmの設定については、/etc/php/8.3/fpm/以下にあります。
+php-fpmの設定については、`/etc/php/8.3/fpm/` 以下にあります。
 
 エラーなどの出力については、
 
-```
+```bash
 $ sudo journalctl -f -u php8.3-fpm
 $ sudo tail -f /var/log/nginx/error.log
 ```
 
 などで見ることができます。
 
-#### Goへの切り替え方
+#### Go (isu-go) への切り替え方
 
-起動する実装をGoに切り替えるには、以下の操作を行います。
+Ruby実装からGo実装に切り替えるには、以下の操作を行います。まず、Rubyサービスを停止・無効化します:
 
-```
+```bash
 $ sudo systemctl stop isu-ruby
 $ sudo systemctl disable isu-ruby
+```
+
+```bash
 $ sudo systemctl start isu-go
 $ sudo systemctl enable isu-go
 ```
@@ -112,21 +121,22 @@ $ sudo systemctl enable isu-go
 
 エラーなどの出力については、
 
-```
+```bash
 $ sudo journalctl -f -u isu-go
 ```
 
 などで見ることができます。
 
-#### Python への切り替え方
+#### Python (isu-python) への切り替え方
 
-起動する実装を Python（Gunicorn）に切り替えるには、以下の操作を行います。
+Ruby実装からPython実装に切り替えるには、以下の操作を行います。まず、Rubyサービスを停止・無効化します:
 
 ```bash
-# 既存の Ruby 実装を停止・無効化
 $ sudo systemctl stop isu-ruby
 $ sudo systemctl disable isu-ruby
+```
 
+```bash
 # Python 用 systemd ユニットを有効化・起動
 $ sudo systemctl start isu-python
 $ sudo systemctl enable isu-python
@@ -154,7 +164,7 @@ $ sudo journalctl -f -u isu-python
 
 [社内ISUCON 当日レギュレーション](/public_manual.md)
 
-なお、当日レギュレーションと本マニュアルの記述に矛盾がある場合、本マニュアルの記述が優先されます。
+本マニュアルは、競技環境の技術的な詳細と操作手順を提供します。当日レギュレーション (`public_manual.md`) には競技全体のルールが記載されています。原則として、競技ルールについては `public_manual.md` を、技術的な操作や環境については本マニュアルを参照してください。
 
 ### スコアについて
 


### PR DESCRIPTION
This pull request updates `manual.md` to provide more detailed instructions and clarify language-switching procedures for reference implementations. It also improves formatting and adds explanations about the purpose and scope of the manual. The most important changes are grouped below by theme.

### Improved instructions for load testing and score reflection:
* Expanded explanation of load testing, specifying how requests are sent automatically to the application and how scores are updated on the portal site. Added a note about potential delays in score updates.

### Enhanced language-switching procedures:
* Clarified the process for switching between Ruby, PHP, Go, and Python reference implementations, including steps to stop and disable the current service, enable and start the desired service, and modify Nginx settings where applicable. Added specific commands and improved formatting with `bash` code blocks. [[1]](diffhunk://#diff-c5606b5d108d3562fa085b09df701f4c6472a58106d8414b0b2beaafbe82eeebL53-R115) [[2]](diffhunk://#diff-c5606b5d108d3562fa085b09df701f4c6472a58106d8414b0b2beaafbe82eeebL115-R139)

### Improved manual scope and purpose explanation:
* Updated the description of the manual to distinguish between technical instructions provided in the manual and competition rules outlined in `public_manual.md`. This helps users understand where to find relevant information.