### PR TITLE
Add webapp/python and webapp/node to CI workflow triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - "webapp/golang/**"
       - "webapp/ruby/**"
       - "webapp/php/**"
+      - "webapp/python/**"
+      - "webapp/node/**"
       - "benchmarker/**"
       - ".github/workflows/ci.yml"
       - "Makefile"


### PR DESCRIPTION
This pull request updates the CI workflow configuration to include additional directories for triggering workflows. Specifically, it adds support for changes in Python and Node.js directories.

Workflow configuration updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR9-R10): Added `webapp/python/**` and `webapp/node/**` to the list of paths that trigger CI workflows.