### PR TITLE
auto-update node-version

### DIFF
--- a/provisioning/image/ansible/04_xbuild.yml
+++ b/provisioning/image/ansible/04_xbuild.yml
@@ -15,6 +15,7 @@
       args:
         creates: /home/isucon/.local/ruby/bin/ruby
     # node
+    # datasource=node-version depName=node
     - command: /home/isucon/.xbuild/node-install v22.16.0 /home/isucon/.local/node
       args:
         creates: /home/isucon/.local/node/bin/node

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
         "/provisioning/image/ansible/04_xbuild.yml/"
       ],
       "matchStrings": [
-        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?-install (?<currentValue>[0-9.]*).*\n"
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\n.*?-install v?(?<currentValue>[0-9.]*).*\n"
       ]
     },
     {


### PR DESCRIPTION
This pull request includes updates to the `provisioning/image/ansible/04_xbuild.yml` and `renovate.json` files to improve version parsing for dependencies. The changes ensure compatibility with version strings that include a leading "v".

Dependency version parsing improvements:

* [`provisioning/image/ansible/04_xbuild.yml`](diffhunk://#diff-98c41b0ee9c9e773db5f54e36e304eaa24d706f00eb5510bafc7702a407d1bd5R18): Added a comment specifying the data source and dependency name for the Node.js installation process.
* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L12-R12): Updated the regular expression in the `matchStrings` property to allow parsing version strings with an optional leading "v".