### PR TITLE
use @types/connect-memcached

### DIFF
--- a/webapp/node/package-lock.json
+++ b/webapp/node/package-lock.json
@@ -8,6 +8,8 @@
       "name": "private-isu-node",
       "version": "1.0.0",
       "dependencies": {
+        "@types/connect-memcached": "^1.0.3",
+        "@types/express-session": "^1.18.2",
         "connect-memcached": "^2.0.0",
         "ejs": "^3.1.9",
         "express": "^5.0.0",
@@ -20,7 +22,6 @@
         "@types/ejs": "^3.1.4",
         "@types/express": "^5.0.0",
         "@types/express-flash": "^0.0.5",
-        "@types/express-session": "^1.18.2",
         "@types/multer": "^1.4.7",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.2"
@@ -91,7 +92,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -101,9 +101,18 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect-memcached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/connect-memcached/-/connect-memcached-1.0.3.tgz",
+      "integrity": "sha512-T+K38cg4j8jWH6GwXCMU20b3qJMax/8QaPmMFi9LbJAlit1kYAv4wwNcKHaZ52pQc56+qOOKTAwwm05wOSn6zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express-session": "*",
+        "@types/memcached": "*"
       }
     },
     "node_modules/@types/ejs": {
@@ -116,7 +125,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
       "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -138,7 +146,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
       "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -151,7 +158,7 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.2.tgz",
       "integrity": "sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*"
       }
@@ -159,14 +166,21 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="
+    },
+    "node_modules/@types/memcached": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
+      "integrity": "sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/multer": {
       "version": "1.4.13",
@@ -181,7 +195,6 @@
       "version": "24.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
       "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -189,20 +202,17 @@
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
       "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -212,7 +222,6 @@
       "version": "1.15.8",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
       "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
-      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*",
@@ -2275,8 +2284,7 @@
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/webapp/node/package.json
+++ b/webapp/node/package.json
@@ -8,6 +8,8 @@
     "start": "node dist/app.js"
   },
   "dependencies": {
+    "@types/connect-memcached": "^1.0.3",
+    "@types/express-session": "^1.18.2",
     "connect-memcached": "^2.0.0",
     "ejs": "^3.1.9",
     "express": "^5.0.0",
@@ -20,7 +22,6 @@
     "@types/ejs": "^3.1.4",
     "@types/express": "^5.0.0",
     "@types/express-flash": "^0.0.5",
-    "@types/express-session": "^1.18.2",
     "@types/multer": "^1.4.7",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.2"

--- a/webapp/node/src/types/connect-memcached.d.ts
+++ b/webapp/node/src/types/connect-memcached.d.ts
@@ -1,1 +1,0 @@
-declare module 'connect-memcached';


### PR DESCRIPTION
This pull request updates the dependencies in `webapp/node/package-lock.json` and `webapp/node/package.json`. The primary changes include adding new type definitions for `connect-memcached` and `express-session`, removing redundant entries, and updating metadata for several dependencies. It also removes the `dev` flag from multiple type dependencies, indicating they are now part of production dependencies.

### Dependency Updates:
* Added `@types/connect-memcached` and `@types/express-session` to both `webapp/node/package-lock.json` and `webapp/node/package.json` to provide type definitions for `connect-memcached` and `express-session`. [[1]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32R11-R12) [[2]](diffhunk://#diff-390fc684c01121baa41f5c8c5a4c780e0db9b267b2ddc02fb84a0ad98e88c44bR11-R12)

### Metadata Adjustments:
* Removed the `dev` flag from several type dependencies in `webapp/node/package-lock.json`, such as `@types/body-parser`, `@types/connect`, and others, indicating these are now production dependencies. [[1]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L94) [[2]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L104-R117) [[3]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L119) [[4]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L141) [[5]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L154-R183) [[6]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L184-L205) [[7]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L215) [[8]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L2278-R2287)

### Redundant Entry Removal:
* Removed duplicate entries for `@types/express-session` from both `webapp/node/package-lock.json` and `webapp/node/package.json`. [[1]](diffhunk://#diff-fb3904bc87409db0e9bf85695178e70d1c5906bca5cac39b0f0be12c15932d32L23) [[2]](diffhunk://#diff-390fc684c01121baa41f5c8c5a4c780e0db9b267b2ddc02fb84a0ad98e88c44bL23)