### PR TITLE
add TypeScript and Python to CodeQL analysis matrix languages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "ruby"]
+        language: ["go", "ruby", "javascript-typescript", "python"]
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both


### PR DESCRIPTION
This pull request updates the CodeQL workflow configuration to expand language support for code analysis.

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L43-R43): Added `typescript` and `python` to the `language` matrix in the CodeQL workflow, enabling analysis for these languages alongside existing support for `go` and `ruby`.