### PR TITLE
refactor: remove any from TypeScript

### DIFF
--- a/webapp/node/src/app.ts
+++ b/webapp/node/src/app.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { serve } from '@hono/node-server'
 import { getCookie, setCookie } from 'hono/cookie'
 import { serveStatic } from '@hono/node-server/serve-static'
@@ -15,6 +15,7 @@ type Variables = {
 }
 
 const app = new Hono<{ Variables: Variables }>()
+type AppContext = Context<{ Variables: Variables }>
 
 const POSTS_PER_PAGE = 20
 const UPLOAD_LIMIT = 10 * 1024 * 1024
@@ -174,7 +175,7 @@ async function makePosts(posts: Post[], options: { allComments?: boolean } = {})
   return Promise.all(posts.map((p) => makePost(p, options)))
 }
 
-async function render(c: any, view: string, params: Record<string, unknown>) {
+async function render(c: AppContext, view: string, params: Record<string, unknown>) {
   const session = c.get('session') as SessionData
   const messages = { notice: session.flashNotice }
   session.flashNotice = undefined
@@ -182,7 +183,7 @@ async function render(c: any, view: string, params: Record<string, unknown>) {
   return c.html(html)
 }
 
-async function getSessionUser(c: any): Promise<User | undefined> {
+async function getSessionUser(c: AppContext): Promise<User | undefined> {
   const session = c.get('session') as SessionData
   if (!session.userId) return undefined
   const [rows] = await db.query<RowDataPacket[]>('SELECT * FROM `users` WHERE `id` = ?', [session.userId])


### PR DESCRIPTION
This pull request refactors the `webapp/node/src/app.ts` file to improve type safety by introducing a new `AppContext` type based on `Hono`'s `Context`. This ensures that functions interacting with the app's context use a strongly typed structure, reducing potential runtime errors and improving code clarity.

### Type safety improvements:

* [`webapp/node/src/app.ts`](diffhunk://#diff-33c0436ad18142d684cee950b95fb31f1b37e725a8b4e65668bdff5489b27bd4L1-R1): Added `type Context` from `Hono` and defined a new type `AppContext` to represent the app's context with typed variables. This enhances type safety across the application. [[1]](diffhunk://#diff-33c0436ad18142d684cee950b95fb31f1b37e725a8b4e65668bdff5489b27bd4L1-R1) [[2]](diffhunk://#diff-33c0436ad18142d684cee950b95fb31f1b37e725a8b4e65668bdff5489b27bd4R18)
* [`webapp/node/src/app.ts`](diffhunk://#diff-33c0436ad18142d684cee950b95fb31f1b37e725a8b4e65668bdff5489b27bd4L177-R186): Updated the `render` function to use `AppContext` instead of a generic `any` type for the `c` parameter, ensuring type safety when accessing session data and rendering views.
* [`webapp/node/src/app.ts`](diffhunk://#diff-33c0436ad18142d684cee950b95fb31f1b37e725a8b4e65668bdff5489b27bd4L177-R186): Updated the `getSessionUser` function to use `AppContext` for the `c` parameter, providing a strongly typed structure when retrieving session data and querying the database.