### PR TITLE
Enable clear_env directive in PHP-FPM config for Ubuntu 24.04

### DIFF
--- a/provisioning/image/ansible/04_xbuild.yml
+++ b/provisioning/image/ansible/04_xbuild.yml
@@ -77,6 +77,13 @@
         line: 'listen = 127.0.0.1:9000'
       when: ansible_distribution == "Ubuntu" and ansible_distribution_version == "24.04"
       tags: php8
+    - name: Mod clear_env directive in PHP-FPM config
+      lineinfile:
+        path: /etc/php/8.3/fpm/pool.d/www.conf
+        insertafter: '^;clear_env = no'
+        line: 'clear_env = no'
+      when: ansible_distribution == "Ubuntu" and ansible_distribution_version == "24.04"
+      tags: php8
     - name: stop php-fpm
       service: name=php8.3-fpm state=stopped enabled=no
       when: ansible_distribution == "Ubuntu" and ansible_distribution_version == "24.04"


### PR DESCRIPTION
This pull request introduces a change to the `provisioning/image/ansible/04_xbuild.yml` file, adding a task to modify the `clear_env` directive in the PHP-FPM configuration file for Ubuntu 24.04 systems.

Provisioning changes:

* [`provisioning/image/ansible/04_xbuild.yml`](diffhunk://#diff-98c41b0ee9c9e773db5f54e36e304eaa24d706f00eb5510bafc7702a407d1bd5R80-R86): Added a new task to update the `clear_env` directive in the PHP-FPM configuration (`www.conf`) to ensure it is set to `no`. This change is applied only for Ubuntu 24.04 systems and tagged with `php8`.