### PR TITLE
remove foreman

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ bunzip2 -c webapp/sql/dump.sql.bz2 | mysql -uroot
 
 cd webapp/ruby
 bundle install --path=vendor/bundle
-bundle exec foreman start
+bundle exec unicorn -c unicorn_config.rb
 cd ../..
 
 cd benchmarker

--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -14,4 +14,4 @@ RUN bundle config set --local path 'vendor/bundle'
 RUN bundle install
 COPY . /home/webapp
 
-ENTRYPOINT [ "bundle", "exec", "foreman", "start" ]
+ENTRYPOINT ["bundle", "exec", "unicorn", "-c", "unicorn_config.rb"]

--- a/webapp/ruby/Gemfile
+++ b/webapp/ruby/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 gem "sinatra"
 gem "sinatra-contrib"
 gem "rack"
-gem "foreman"
 gem "unicorn"
 gem 'bigdecimal'
 gem "mysql2"

--- a/webapp/ruby/Gemfile.lock
+++ b/webapp/ruby/Gemfile.lock
@@ -1,14 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
+    base64 (0.3.0)
     bigdecimal (3.2.2)
     connection_pool (2.5.3)
     dalli (3.2.8)
-    foreman (0.88.1)
     kgio (2.11.4)
-    logger (1.6.6)
-    multi_json (1.15.0)
+    logger (1.7.0)
+    multi_json (1.17.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.6)
@@ -37,7 +36,7 @@ GEM
       rack-protection (= 4.1.1)
       sinatra (= 4.1.1)
       tilt (~> 2.0)
-    tilt (2.6.0)
+    tilt (2.6.1)
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -50,7 +49,6 @@ DEPENDENCIES
   bigdecimal
   connection_pool
   dalli
-  foreman
   mysql2
   rack
   rack-flash3

--- a/webapp/ruby/Procfile
+++ b/webapp/ruby/Procfile
@@ -1,1 +1,0 @@
-unicorn: bundle exec unicorn -c unicorn_config.rb


### PR DESCRIPTION
This pull request updates the Ruby web application to replace `foreman` with `unicorn` as the application server. The changes involve modifications to the Dockerfile, Gemfile, and Procfile to support this migration.

### Migration to `unicorn`:

* **Dockerfile**: Updated the `ENTRYPOINT` to use `unicorn` with the specified configuration file `unicorn_config.rb`, replacing the previous `foreman` command. (`[webapp/ruby/DockerfileL17-R17](diffhunk://#diff-db9df8fe5c9eee88b83dd16cc569a178298d0bb466f9c931d974ddfa8965fb78L17-R17)`)
* **Gemfile**: Removed the `foreman` gem and added the `unicorn` gem to manage the application server. (`[webapp/ruby/GemfileL7](diffhunk://#diff-6e19613ea91322b3a139158112bbd60589297610206a95c0d56abfc51ed47e67L7)`)
* **Procfile**: Removed the `unicorn` command entry, as it is no longer needed with the updated Dockerfile configuration. (`[webapp/ruby/ProcfileL1](diffhunk://#diff-0868c502c4e9bd4906cae01ff962f2079174136a8e710938d5b9390e3b135d44L1)`)