### PR TITLE
fix: resolve build error in image response.

### DIFF
--- a/webapp/node/src/app.ts
+++ b/webapp/node/src/app.ts
@@ -360,7 +360,7 @@ app.get('/image/:filename{[0-9]+\\.(png|jpg|gif)}', async (c) => {
     const post = (posts as Post[])[0]
     if (!post) return c.text('image not found', 404)
     if ((ext === 'jpg' && post.mime === 'image/jpeg') || (ext === 'png' && post.mime === 'image/png') || (ext === 'gif' && post.mime === 'image/gif')) {
-      return new Response(post.imgdata, { headers: { 'Content-Type': post.mime } })
+      return new Response(new Uint8Array(post.imgdata), { headers: { 'Content-Type': post.mime } })
     }
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
# Summary
- When trying to use the Node.js implementation, I encountered the following build errors.  
This PR resolves these errors.

```
#14 [stage-0 7/7] RUN npm run build
#14 0.521 
#14 0.521 > private-isu-node@1.0.0 build
#14 0.521 > tsc
#14 0.521 
#14 2.698 src/app.ts(363,27): error TS2345: Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'BodyInit | null | undefined'.
#14 2.698   Type 'Buffer<ArrayBufferLike>' is missing the following properties from type 'URLSearchParams': size, append, delete, get, and 2 more.
#14 ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 2
------
 > [stage-0 7/7] RUN npm run build:
0.521 
0.521 > private-isu-node@1.0.0 build
0.521 > tsc
0.521 
2.698 src/app.ts(363,27): error TS2345: Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'BodyInit | null | undefined'.
2.698   Type 'Buffer<ArrayBufferLike>' is missing the following properties from type 'URLSearchParams': size, append, delete, get, and 2 more.
------
Dockerfile:16

--------------------

  14 |     

  15 |     COPY . .

  16 | >>> RUN npm run build

  17 |     

  18 |     CMD [ "node", "dist/app.js" ]

--------------------

failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 2
``` 

# Build check
- I attach the build log that verifies whether the build succeeds when the Node.js implementation is specified in Docker Compose.

## Before
<img width="1118" height="487" alt="image" src="https://github.com/user-attachments/assets/b9418071-df45-4466-97ae-afab0c805af7" />

## After
<img width="1120" height="502" alt="image" src="https://github.com/user-attachments/assets/d4b1896e-fed2-4634-8ff3-2d9b29303e4d" />
