### PR TITLE
use unicorn from git with custom build steps for Ruby 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ bunzip2 -c webapp/sql/dump.sql.bz2 | mysql -uroot
 
 cd webapp/ruby
 bundle install --path=vendor/bundle
+bundle exec ruby prepare_unicorn.rb
 bundle exec unicorn -c unicorn_config.rb
 cd ../..
 

--- a/provisioning/image/ansible/00_base.yml
+++ b/provisioning/image/ansible/00_base.yml
@@ -8,6 +8,7 @@
     - apt: upgrade=dist
     - apt: name=build-essential state=present
     - apt: name=git state=present
+    - apt: name=ragel state=present
     - apt: name=gcc state=present
     - apt: name=patch state=present
     - apt: name=autoconf state=present

--- a/provisioning/image/ansible/07_application.yml
+++ b/provisioning/image/ansible/07_application.yml
@@ -4,7 +4,7 @@
   gather_facts: no
   tasks:
     - name: bundle install
-      shell: cd /home/isucon/private_isu/webapp/ruby; bash -lc "bundle install"
+      shell: cd /home/isucon/private_isu/webapp/ruby; bash -lc "bundle install && bundle exec ruby prepare_unicorn.rb"
 
 - hosts: guests:extras
   become: yes

--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -1,16 +1,37 @@
 #syntax=docker/dockerfile:1
-FROM ruby:3.4-slim
+FROM ruby:4.0-slim
 
 RUN \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
   apt-get update -qq \
-  && apt-get install -y build-essential default-libmysqlclient-dev \
+  && apt-get install -y build-essential default-libmysqlclient-dev git ragel \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/webapp
 COPY Gemfile Gemfile.lock ./
-RUN bundle config set --local path 'vendor/bundle' && bundle install
+RUN bundle config set --local path 'vendor/bundle' \
+  && bundle install \
+  && ruby -e "require 'fileutils'; \
+    gs = Dir['vendor/bundle/**/unicorn.gemspec']; \
+    abort('unicorn.gemspec not found') if gs.empty?; \
+    gs.each do |g| \
+      spec = Gem::Specification.load(g); \
+      dir = File.dirname(g); \
+      ver_path = File.join(dir, 'lib', 'unicorn', 'version.rb'); \
+      FileUtils.mkdir_p(File.dirname(ver_path)); \
+      File.write(ver_path, \"# frozen_string_literal: true\\nmodule Unicorn\\n  module Const\\n    UNICORN_VERSION = '#{spec.version}'\\n  end\\n  VERSION = Const::UNICORN_VERSION\\nend\\n\"); \
+      ext_dir = File.join(dir, 'ext', 'unicorn_http'); \
+      Dir.chdir(ext_dir) do \
+        system('rake', 'ragel') || system('ragel', '-G2', 'unicorn_http.rl', '-o', 'unicorn_http.c') or abort('ragel step failed'); \
+        system(Gem.ruby, 'extconf.rb') or abort('extconf.rb failed'); \
+        system('make', 'clean'); \
+        system('make') or abort('make failed'); \
+        system('make', 'install') or abort('make install failed'); \
+      end; \
+      so = Dir[File.join(ext_dir, 'unicorn_http.so'), File.join(dir, 'lib', 'unicorn_http.so')].first; \
+      FileUtils.cp(so, File.join(dir, 'lib', 'unicorn_http.so')) if so; \
+    end"
 COPY . .
 
 ENTRYPOINT ["bundle", "exec", "unicorn", "-c", "unicorn_config.rb"]

--- a/webapp/ruby/Dockerfile
+++ b/webapp/ruby/Dockerfile
@@ -9,29 +9,10 @@ RUN \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/webapp
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock prepare_unicorn.rb ./
 RUN bundle config set --local path 'vendor/bundle' \
   && bundle install \
-  && ruby -e "require 'fileutils'; \
-    gs = Dir['vendor/bundle/**/unicorn.gemspec']; \
-    abort('unicorn.gemspec not found') if gs.empty?; \
-    gs.each do |g| \
-      spec = Gem::Specification.load(g); \
-      dir = File.dirname(g); \
-      ver_path = File.join(dir, 'lib', 'unicorn', 'version.rb'); \
-      FileUtils.mkdir_p(File.dirname(ver_path)); \
-      File.write(ver_path, \"# frozen_string_literal: true\\nmodule Unicorn\\n  module Const\\n    UNICORN_VERSION = '#{spec.version}'\\n  end\\n  VERSION = Const::UNICORN_VERSION\\nend\\n\"); \
-      ext_dir = File.join(dir, 'ext', 'unicorn_http'); \
-      Dir.chdir(ext_dir) do \
-        system('rake', 'ragel') || system('ragel', '-G2', 'unicorn_http.rl', '-o', 'unicorn_http.c') or abort('ragel step failed'); \
-        system(Gem.ruby, 'extconf.rb') or abort('extconf.rb failed'); \
-        system('make', 'clean'); \
-        system('make') or abort('make failed'); \
-        system('make', 'install') or abort('make install failed'); \
-      end; \
-      so = Dir[File.join(ext_dir, 'unicorn_http.so'), File.join(dir, 'lib', 'unicorn_http.so')].first; \
-      FileUtils.cp(so, File.join(dir, 'lib', 'unicorn_http.so')) if so; \
-    end"
+  && bundle exec ruby prepare_unicorn.rb
 COPY . .
 
 ENTRYPOINT ["bundle", "exec", "unicorn", "-c", "unicorn_config.rb"]

--- a/webapp/ruby/Gemfile
+++ b/webapp/ruby/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 gem "sinatra"
 gem "sinatra-contrib"
 gem "rack"
-gem "unicorn"
+gem "unicorn", git: "https://github.com/defunkt/unicorn.git", ref: "e9862718a7e98d3cbec74fc92ffc17a1023e18da"
 gem 'bigdecimal'
 gem "mysql2"
 gem "rack-flash3"

--- a/webapp/ruby/Gemfile
+++ b/webapp/ruby/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 gem "sinatra"
 gem "sinatra-contrib"
 gem "rack"
+# The released unicorn gem has not been updated for Ruby 4 yet, so use the
+# unreleased git revision until a compatible gem is published.
 gem "unicorn", git: "https://github.com/defunkt/unicorn.git", ref: "e9862718a7e98d3cbec74fc92ffc17a1023e18da"
 gem 'bigdecimal'
 gem "mysql2"

--- a/webapp/ruby/Gemfile.lock
+++ b/webapp/ruby/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/defunkt/unicorn.git
+  revision: e9862718a7e98d3cbec74fc92ffc17a1023e18da
+  ref: e9862718a7e98d3cbec74fc92ffc17a1023e18da
+  specs:
+    unicorn (6.1.0)
+      raindrops (~> 0.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -6,7 +14,6 @@ GEM
     connection_pool (3.0.2)
     dalli (5.0.3)
       logger
-    kgio (2.11.4)
     logger (1.7.0)
     multi_json (1.21.1)
     mustermann (3.1.1)
@@ -37,9 +44,6 @@ GEM
       sinatra (= 4.2.1)
       tilt (~> 2.0)
     tilt (2.7.0)
-    unicorn (6.1.0)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
 
 PLATFORMS
   aarch64-linux
@@ -54,7 +58,7 @@ DEPENDENCIES
   rack-flash3
   sinatra
   sinatra-contrib
-  unicorn
+  unicorn!
 
 BUNDLED WITH
    2.6.2

--- a/webapp/ruby/prepare_unicorn.rb
+++ b/webapp/ruby/prepare_unicorn.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+# The unreleased git revision is needed for Ruby 4, but git installs do not
+# include the generated files that are present in released gems.
+spec = Gem.loaded_specs["unicorn"]
+abort("unicorn gem not found") unless spec
+
+dir = spec.full_gem_path
+
+version_path = File.join(dir, "lib", "unicorn", "version.rb")
+FileUtils.mkdir_p(File.dirname(version_path))
+File.write(version_path, <<~RUBY)
+  # frozen_string_literal: true
+  module Unicorn
+    module Const
+      UNICORN_VERSION = "#{spec.version}"
+    end
+    VERSION = Const::UNICORN_VERSION
+  end
+RUBY
+
+ext_dir = File.join(dir, "ext", "unicorn_http")
+Dir.chdir(ext_dir) do
+  system("ragel", "-G2", "unicorn_http.rl", "-o", "unicorn_http.c") || abort("ragel step failed")
+  system(Gem.ruby, "extconf.rb") || abort("extconf.rb failed")
+  system("make", "clean")
+  system("make") || abort("make failed")
+  system("make", "install") || abort("make install failed")
+end
+
+shared_object = Dir[File.join(ext_dir, "unicorn_http.so"), File.join(dir, "lib", "unicorn_http.so")].first
+FileUtils.cp(shared_object, File.join(dir, "lib", "unicorn_http.so")) if shared_object


### PR DESCRIPTION
This pull request updates the Ruby web application to support Ruby 4 by switching to an unreleased git version of the `unicorn` gem and ensuring its native extension is properly built. It also adds the necessary system dependencies and build steps to support this change in both Docker and Ansible provisioning, and introduces a new script, `prepare_unicorn.rb`, to handle the build process.

**Support for Ruby 4 and unicorn compatibility:**

* Changed the `unicorn` gem in `Gemfile` to use a specific unreleased git revision that is compatible with Ruby 4, since the released version does not yet support Ruby 4.
* Added a new script, `prepare_unicorn.rb`, which generates the missing `version.rb` file and builds the native extension using `ragel` and `make`, ensuring the unicorn gem functions correctly when installed from git.

**Build and provisioning updates:**

* Updated the Dockerfile to use `ruby:4.0-slim`, install `ragel` and `git`, copy and run `prepare_unicorn.rb` during the build, and ensure all dependencies are installed.
* Updated Ansible provisioning (`00_base.yml` and `07_application.yml`) to install `ragel` and run `prepare_unicorn.rb` after bundle install. [[1]](diffhunk://#diff-a7e9be04175cc75cb58ffa511438f7a45ee30ae25e3da6d3d7356c64780eb3ffR11) [[2]](diffhunk://#diff-2d140b5b87423bf5fbe3d00261b1bcb65a21640908e185e78bf1c5b5e8feae04L7-R7)

**Documentation:**

* Updated the setup instructions in `README.md` to include running `prepare_unicorn.rb` before starting the unicorn server.