### PR TITLE
Split lock file maintenance PRs by application in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,62 @@
   ],
   "packageRules": [
     {
+      "description": [
+        "Keep lock file maintenance PRs split by application."
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "matchFileNames": [
+        "webapp/ruby/Gemfile",
+        "webapp/ruby/Gemfile.lock"
+      ],
+      "branchTopic": "ruby-lock-file-maintenance",
+      "commitMessageTopic": "Ruby lock file"
+    },
+    {
+      "description": [
+        "Keep lock file maintenance PRs split by application."
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "matchFileNames": [
+        "webapp/php/composer.json",
+        "webapp/php/composer.lock"
+      ],
+      "branchTopic": "php-lock-file-maintenance",
+      "commitMessageTopic": "PHP lock file"
+    },
+    {
+      "description": [
+        "Keep lock file maintenance PRs split by application."
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "matchFileNames": [
+        "webapp/node/package.json",
+        "webapp/node/package-lock.json"
+      ],
+      "branchTopic": "node-lock-file-maintenance",
+      "commitMessageTopic": "Node lock file"
+    },
+    {
+      "description": [
+        "Keep lock file maintenance PRs split by application."
+      ],
+      "matchUpdateTypes": [
+        "lockFileMaintenance"
+      ],
+      "matchFileNames": [
+        "webapp/python/pyproject.toml",
+        "webapp/python/uv.lock"
+      ],
+      "branchTopic": "python-lock-file-maintenance",
+      "commitMessageTopic": "Python lock file"
+    },
+    {
       "matchDatasources": [
         "docker"
       ],


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve how lock file maintenance pull requests are handled for different applications. The main change is to ensure that lock file maintenance PRs are split by application, making it easier to track and review dependency updates for each tech stack separately.

**Lock file maintenance configuration:**

* Added new `packageRules` entries to split lock file maintenance PRs by application for Ruby, PHP, Node, and Python. Each entry matches the relevant lock files and sets a specific branch topic and commit message topic for that application.