### PR TITLE
update AMI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ /home/isucon/private_isu/benchmarker/bin/benchmarker -u /home/isucon/private_i
 
 以下のAMI IDで起動できます（リージョンは `ap-northeast-1` （アジアパシフィック (東京)））。これは特定日時のスナップショットのため、より新しいAMIが利用可能になっている場合があります。AWSコンソールで最新情報を確認することをお勧めします。推奨インスタンスタイプは、競技者用が`c7a.large`、ベンチマーカー用が`c7a.xlarge`です。
 
-競技者用 (Ubuntu 24.04, amd64): [`catatsuy_private_isu_amd64_20250615`](https://ap-northeast-1.console.aws.amazon.com/ec2/home?region=ap-northeast-1#ImageDetails:imageId=ami-002d61d6436f85f12)
+競技者用 (Ubuntu 24.04, amd64): [`catatsuy_private_isu_amd64_20260524`](https://ap-northeast-1.console.aws.amazon.com/ec2/home?region=ap-northeast-1#ImageDetails:imageId=ami-09201e964bee13733)
 
 ### 手元で動かす
 


### PR DESCRIPTION
This pull request updates the documentation to reference a newer AMI for the competitor environment. The change ensures users are directed to the latest recommended image when setting up their environment.

- Documentation update:
  * Updated the competitor AMI ID and link in the `README.md` to point to `catatsuy_private_isu_amd64_20260524` (ami-09201e964bee13733), replacing the previous AMI reference.