### PR TITLE
fix(benchmarker): drop Content-Type when following redirects

### DIFF
--- a/benchmarker/checker/session.go
+++ b/benchmarker/checker/session.go
@@ -44,6 +44,15 @@ func NewSession() *Session {
 		Transport: w.Transport,
 		Jar:       jar,
 		Timeout:   time.Duration(10) * time.Second,
+		// ブラウザ同様、リダイレクト先へボディ関連のヘッダを持ち越さない。
+		// multipart の Content-Type が残ると空ボディをパースしようとして 400 になる
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			req.Header.Del("Content-Type")
+			return nil
+		},
 	}
 
 	return w


### PR DESCRIPTION
## 概要

Go の http.Client はリダイレクト先のリクエストにも元のヘッダをコピーするため、POST / の multipart Content-Type がリダイレクト後の GET /posts/:id まで引き継がれていました。

Rack 3.2 はボディのない multipart リクエストに対して Rack::Multipart::EmptyContentError を投げるので、Sinatra が 400 を返しベンチマークが失敗します。ブラウザはリダイレクト時にこのヘッダを落とすため、同じ挙動に揃えたいです。

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP redirect handling by limiting redirect chains to 10 redirects.
  * Removed the `Content-Type` header from redirected requests to improve request compatibility.

