### PR TITLE
exclude unicorn git-refs due to RubyGems registry

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -171,6 +171,22 @@
       "minimumReleaseAge": "0 days"
     },
     {
+      "description": [
+        "Bundler incorrectly passes the RubyGems registry to git-refs dependencies.",
+        "See https://github.com/renovatebot/renovate/issues/37432."
+      ],
+      "matchManagers": [
+        "bundler"
+      ],
+      "matchDatasources": [
+        "git-refs"
+      ],
+      "matchPackageNames": [
+        "https://github.com/defunkt/unicorn.git"
+      ],
+      "registryUrls": []
+    },
+    {
       "matchManagers": [
         "bundler"
       ],


### PR DESCRIPTION
refs: https://github.com/renovatebot/renovate/issues/37432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to correctly handle the Bundler Git-based Unicorn dependency.
  * Prevented incorrect RubyGems registry usage for this dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->