### PR TITLE
Enable indirect dependency updates for Go modules in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -188,6 +188,15 @@
     },
     {
       "matchManagers": [
+        "gomod"
+      ],
+      "matchDepTypes": [
+        "indirect"
+      ],
+      "enabled": true
+    },
+    {
+      "matchManagers": [
         "bundler"
       ],
       "rangeStrategy": "update-lockfile"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated update management for indirect Go module dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->